### PR TITLE
fix install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,6 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+# dotfiles
+roles.txt
 

--- a/_tools/create/dependencies
+++ b/_tools/create/dependencies
@@ -1,0 +1,1 @@
+homebrew

--- a/_tools/install_all.sh
+++ b/_tools/install_all.sh
@@ -16,7 +16,7 @@ main() {
       [[ $role =~ ^# ]] && continue
       roles="$roles $role"
     done < <(cat $DOTF_ROLES_FILE)
-    roles=$(echo "${roles}" | tr ' ' '\n' | sed '/^$/d' | sort | uniq)
+    roles=$(echo "${roles}" | tr ' ' '\n' | sed '/^$/d')
   else
     roles=$(find roles ! -path './_tools*' -a ! -path './.git*' -a -name 'install.sh' | sort)
   fi

--- a/roles/aws-nuke/install.sh
+++ b/roles/aws-nuke/install.sh
@@ -9,6 +9,7 @@ cd $HOME/bin
 curl -sOL https://github.com/rebuy-de/aws-nuke/releases/download/v${AWS_NUKE_VERSION}/aws-nuke-v${AWS_NUKE_VERSION}.dirty-darwin-arm64.tar.gz
 tar zxvf aws-nuke-v${AWS_NUKE_VERSION}.dirty-darwin-arm64.tar.gz
 mv -f aws-nuke-v${AWS_NUKE_VERSION}.dirty-darwin-arm64 aws-nuke
+rm -f aws-nuke-v${AWS_NUKE_VERSION}.dirty-darwin-arm64.tar.gz
 )
 
 (

--- a/roles/macvim/.zprofile
+++ b/roles/macvim/.zprofile
@@ -1,4 +1,4 @@
-# NOTE: 
+# NOTE:
 # 基本的に ~/.zshrc に全て定義しており、~/.zprofile は使用しない方針であったが、以下の対応で必要になったので、MacVim スペシャル対応として作成する。
 # refs. https://github.com/macvim-dev/macvim/wiki/Troubleshooting#for-zsh-users
 #

--- a/roles/vim/install.sh
+++ b/roles/vim/install.sh
@@ -5,9 +5,9 @@ readonly CURRENT_PATH=$(cd $(dirname $0); pwd)
 
 
 brew list vim > /dev/null 2>&1 || {
-  brew list macvim > /dev/null 2>&1 && {
-    brew unlink macvim
-  }
+#  brew list macvim > /dev/null 2>&1 && {
+#    brew unlink macvim
+#  }
   brew install vim
 }
 

--- a/roles/zsh/.zsh.d/dircolors.zshrc
+++ b/roles/zsh/.zsh.d/dircolors.zshrc
@@ -1,3 +1,3 @@
 # Nort dircolors: https://www.nordtheme.com/ports/dircolors
-test -r ~/.dir_colors && eval $(dircolors ~/.dir_colors)
+test -r ~/.dir_colors && eval $(dircolors ~/.dir_colors) || true
 


### PR DESCRIPTION
以下のインストールに失敗した箇所を修正した（その他の修正は雑多なついでの修正）。

- feat(install): DOTF_ROLES_FILE was changed to read in the order listed.
- fix(zsh/dircolors): Changed to always TRUE
- fix(vim): 仮対応: Remove uninstall macvim

Ref. #45

