### PR TITLE
Add vim/direnv plugin

### DIFF
--- a/roles/vim/.vimrc
+++ b/roles/vim/.vimrc
@@ -142,6 +142,7 @@ Plug 'rafamadriz/friendly-snippets'
 Plug 'thinca/vim-quickrun'
 Plug 'editorconfig/editorconfig-vim'
 Plug 'mattn/vim-sonictemplate'
+Plug 'direnv/direnv.vim'
 call plug#end()
 
 


### PR DESCRIPTION
vim-quickrun を使うときに、direnv で設定した環境変数がエクスポートされておらず、やり辛かったため導入した。
デフォルトで、ロードされるため特に設定はない。手動で環境変数をロードしたい場合は、:DirenvExport を打てば良い。