### PR TITLE
feat(vim): Remove 'cnoremap <silent> <C-r> :<C-u>FzfHistory:<CR>'

### DIFF
--- a/roles/vim/.vimrc
+++ b/roles/vim/.vimrc
@@ -216,7 +216,6 @@ nnoremap <silent> <LocalLeader>b :<C-u>FzfBuffers<CR>
 nnoremap <silent> <LocalLeader>f :<C-u>cd %:p:h<CR> :<C-u>FzfRg<CR>
 nnoremap <silent> <LocalLeader>h :<C-u>FzfHistory<CR>
 nnoremap <silent> <LocalLeader>r :<C-u>FzfHistory:<CR>
-cnoremap <silent> <C-r> :<C-u>FzfHistory:<CR>
 
 command! -bang -nargs=* FzfRg
 \ call fzf#vim#grep(


### PR DESCRIPTION
C-r は、vim 標準キーで使うので開放した。
あと、特にこのキーマップを使わないのでいったん削除した。