### PR TITLE
Fix git-secrets role (say 対応）

### DIFF
--- a/roles/git/install.sh
+++ b/roles/git/install.sh
@@ -33,9 +33,17 @@ GIT_COMMIT="${GIT_CONFIG_ROOT_DIR}/${GIT_COMMIT_FILE}"
 git config --global commit.template "${GIT_COMMIT}"
 
 # Global Git Secret
-brew list git-secrets > /dev/null 2>&1 || {
-  brew install git-secrets
-}
+# ref. https://github.com/awslabs/git-secrets/issues/220#issuecomment-1641285337
+# brew list git-secrets > /dev/null 2>&1 || {
+#   brew install git-secrets
+# }
+(
+workdir=$(mktemp -d)
+git clone https://github.com/awslabs/git-secrets --depth 1 $workdir
+cd $workdir
+sudo make install
+)
+
 GIT_SECRETS="${GIT_CONFIG_ROOT_DIR}/git-secrets"
 git secrets --install ${GIT_SECRETS} --force > /dev/null
 git config --global init.templatedir ${GIT_SECRETS}
@@ -49,4 +57,3 @@ cp -fr .zsh.d ${HOME}
 cp -fr bin ${HOME}
 chmod +x ${HOME}/bin/*
 )
-


### PR DESCRIPTION
最新化されておらず、say コマンド対応されてないので、急に mac が喋りだす。
なので、リンク先のとおり、make install することにした。
brew 管理でなくなるのと、暫定なので、1.3.0 on Feb 11, 2019 以降になれば brew に戻しす（コメント外す）。
