### PR TITLE
Fix install all count

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -64,7 +64,7 @@ _all() {
 
   local role i
   local roles=$(grep -v -e '^\s*#' -e '^\s*$' $DOTF_ROLES_FILE)
-  local all=$(echo $roles | wc -w)
+  local all=$(echo $roles | wc -w | xargs)
 
   for role in ${=roles}; do
     _individual ${role} "$((++i))/$all"


### PR DESCRIPTION
xargs は何もしなければトリム効果があるというハックを使う。
※最初のインストールで、GNU wc を入れるので、ほぼ初めしか使わないが、最初は BSD wc なので。
