### PR TITLE
Update google-japanese-input


### DIFF
--- a/roles/google-japanese-ime/README.md
+++ b/roles/google-japanese-ime/README.md
@@ -1,5 +1,6 @@
 # roles/google-japanese-ime
 Google Japanese IME（Google 日本語入力）
+※開発版をインストールすれば、Rosetta2 は不要なため、手動でインストールする（2024/01/08 時点）。
 
 
 


### PR DESCRIPTION
role.lst からはコメントアウトしている。
開発版を手動でインストールすると良い。
そうすれば、rosetta2 が不要で動いた。
