### PR TITLE
Update nvim 2024-10-19

### DIFF
--- a/roles/nvim/.config/nvim/lua/plugins/utils.lua
+++ b/roles/nvim/.config/nvim/lua/plugins/utils.lua
@@ -32,4 +32,12 @@ return {
     -- end,
   },
 
+  -- https://github.com/previm/previm
+  {
+    'previm/previm',
+    init = function()
+      vim.g.previm_open_cmd = 'open -a Google\\ Chrome'
+    end,
+  },
+
 }


### PR DESCRIPTION
let g:previm_open_cmd = 'open -a Google\ Chrome'
を lazynvim の設定方法で追加

ref. https://github.com/previm/previm/blob/master/README-en.md#usage
