### PR TITLE
Update tmux

### DIFF
--- a/roles/tmux/.tmux.conf
+++ b/roles/tmux/.tmux.conf
@@ -13,7 +13,7 @@
 set -g default-shell /opt/homebrew/bin/zsh                                                                   # tmux default shell set zsh.
 set -g mode-keys vi                                                                                          # vi keybind
 set -g default-command "reattach-to-user-namespace -l $SHELL"                                                # Shared clipboard: vim <-> tmux.
-set -sg escape-time 0                                                                                        # Fix Esc key delay time for Vim
+set -sg escape-time 50                                                                                       # Fix Esc key delay time for Vim
 set -g base-index 1                                                                                          # To Start the index of window from 1.
 set -g pane-base-index 1                                                                                     # To Start the index of pane from 1.
 set -g renumber-windows on                                                                                   # Automatically ReNumber windows


### PR DESCRIPTION
ref. https://zenn.dev/tanktabox/scraps/235a05b5d5fa97

もともとは、nvim on tmux した時に、esc が遅いためつけていた。
が、vscode x tmux すると、起動時に謎のカラーコード？ execute と出てしまう。
なので、50ms にするワークアラウンドで対応した。
これで、esc 時も気にならず、tmux 起動時もエラーは出ない。
