### PR TITLE
feat: Periodic update — 1password/imagemagick roles, claude notification & model

### DIFF
--- a/roles.etc.lst
+++ b/roles.etc.lst
@@ -1,2 +1,3 @@
+1password
 tradingview
 imagemagick

--- a/roles.etc.lst
+++ b/roles.etc.lst
@@ -1,1 +1,2 @@
 tradingview
+imagemagick

--- a/roles.lst
+++ b/roles.lst
@@ -30,3 +30,4 @@ claude
 vscode
 github-actions
 tradingview
+imagemagick

--- a/roles.lst
+++ b/roles.lst
@@ -29,5 +29,6 @@ devbox
 claude
 vscode
 github-actions
+1password
 tradingview
 imagemagick

--- a/roles/1password/README.md
+++ b/roles/1password/README.md
@@ -1,0 +1,18 @@
+# roles/1password
+1Password app. 1Password remembers all your passwords for you. It keeps your digital life secure and always available, safe behind the one password that only you know.
+
+
+
+## Dependencies
+- homebrew
+
+
+
+## Usage
+open 1Password.app
+
+
+
+## References
+- [1Password](https://github.com/1password)
+

--- a/roles/1password/install.sh
+++ b/roles/1password/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+set -e
+
+readonly CURRENT_PATH=$(cd $(dirname $0); pwd)
+
+
+brew list --cask 1password > /dev/null 2>&1 || {
+  brew install 1password --cask
+}
+

--- a/roles/claude/.claude/hooks/notify.sh
+++ b/roles/claude/.claude/hooks/notify.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Claude Code notification hook
+# Usage: notify.sh <message> [sound_name]
+#   $1 = message body (e.g. "DONE" / "WAIT")
+#   $2 = sound name (optional, e.g. "Glass"). Empty = silent.
+#
+# Behavior:
+#   - Builds title "[Claude Code] <window-name>:<window-index>" when running
+#     inside tmux. Outside tmux, title is "[Claude Code]".
+#   - Suppresses notification only when Ghostty is frontmost AND the
+#     currently visible tmux window is the same window that this Claude
+#     instance is running in. Otherwise notifies.
+
+set -u
+
+msg=${1:-""}
+sound=${2:-""}
+
+# Build tab identifier from the pane this Claude was launched in.
+tab=""
+if [ -n "${TMUX_PANE:-}" ]; then
+  tab=$(tmux display-message -t "$TMUX_PANE" -p '#W:#I' 2>/dev/null || true)
+fi
+title="[Claude Code]${tab:+ $tab}"
+
+# Suppression: only skip when Ghostty is frontmost AND user is currently
+# looking at the same tmux window as this Claude instance.
+front=$(osascript -e 'tell application "System Events" to set f to name of first application process whose frontmost is true' 2>/dev/null || true)
+if [ "$front" = "ghostty" ] && [ -n "${TMUX_PANE:-}" ]; then
+  cur=$(tmux display-message -p '#S:#I' 2>/dev/null || true)
+  mine=$(tmux display-message -t "$TMUX_PANE" -p '#S:#I' 2>/dev/null || true)
+  if [ -n "$cur" ] && [ "$cur" = "$mine" ]; then
+    exit 0
+  fi
+fi
+
+# Fire macOS notification.
+if [ -n "$sound" ]; then
+  osascript -e "display notification \"$msg\" with title \"$title\" sound name \"$sound\""
+else
+  osascript -e "display notification \"$msg\" with title \"$title\""
+fi

--- a/roles/claude/.claude/settings.json
+++ b/roles/claude/.claude/settings.json
@@ -1,5 +1,5 @@
 {
-  "model": "claude-opus-4-7",
+  "model": "opus",
   "hooks": {
     "Stop": [
       {
@@ -23,5 +23,6 @@
         ]
       }
     ]
-  }
+  },
+  "theme": "dark-ansi"
 }

--- a/roles/claude/.claude/settings.json
+++ b/roles/claude/.claude/settings.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'tell application \"System Events\" to set f to name of first application process whose frontmost is true' -e 'if f is not \"ghostty\" then display notification \"応答が完了しました\" with title \"Claude Code\"'"
+            "command": "sh ~/.claude/hooks/notify.sh 'DONE' 'Glass'"
           }
         ]
       }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "osascript -e 'tell application \"System Events\" to set f to name of first application process whose frontmost is true' -e 'if f is not \"ghostty\" then display notification \"承認待ちです\" with title \"Claude Code\" sound name \"Glass\"'"
+            "command": "sh ~/.claude/hooks/notify.sh 'WAIT' 'Glass'"
           }
         ]
       }

--- a/roles/imagemagick/README.md
+++ b/roles/imagemagick/README.md
@@ -1,0 +1,21 @@
+# roles/imagemagick
+ImageMagick® is a free and open-source software suite, used for editing and manipulating digital images. It can be used to create, edit, compose, or convert bitmap images, and supports a wide range of file formats, including JPEG, PNG, GIF, TIFF, and PDF.
+
+
+
+## Dependencies
+- homebrew
+
+
+
+## Usage
+```
+# カレントディレクトリにあるすべての HEIC ファイルを 80% の品質で JPEG 画像に変換し新規出力する。
+% fd -e HEIC | while read line; do echo $line; magick $line -quality 80 $line.jpg; done
+```
+
+
+
+## References
+- [ImageMagick/ImageMagick: ImageMagick is a free, open-source software suite for creating, editing, converting, and displaying images. It supports 200+ formats and offers powerful command-line tools and APIs for automation, scripting, and integration across platforms.](https://github.com/imagemagick/imagemagick)
+

--- a/roles/imagemagick/install.sh
+++ b/roles/imagemagick/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env zsh
+set -e
+
+readonly CURRENT_PATH=$(cd $(dirname $0); pwd)
+
+
+brew list imagemagick > /dev/null 2>&1 || {
+  brew install imagemagick
+}
+

--- a/roles/maccy/README.md
+++ b/roles/maccy/README.md
@@ -23,16 +23,16 @@ p0deje/Maccy: Lightweight clipboard manager for macOS
 
 
 ### Pins
-- `fd -e HEIC | while read line; do echo $line; convert $line -quality 80 $line.jpg; done`
+- `fd -e HEIC | while read line; do echo $line; magick $line -quality 80 $line.jpg; done`
 - `finch run -it --rm public.ecr.aws/debian/debian:stable-slim /bin/bash`
 - `git rebase -i $(gci-rebase)`
-- 
+-
   ```
   <details>
   <summary>XXX</summary>
-  
+
   XXX
-  
+
   </details>
   ```
 


### PR DESCRIPTION
## 概要
定期アップデート。複数の細かい変更をまとめています。

## 変更内容
- **feat: Add imagemagick role** — imagemagick の role を追加
- **feat: Add 1password role** — 1password の role を追加
- **feat: Update claude notification hook with tmux tab identifier**
  - 通知ロジックを inline の osascript から専用スクリプト `notify.sh` に切り出し
  - 通知タイトルに tmux ウィンドウ識別子 (`<window-name>:<index>`) を付与し、複数 tmux ウィンドウでの並行運用時にどのウィンドウからの通知か判別可能に
  - 抑制条件を「Ghostty 前面 かつ 表示中の tmux ウィンドウが Claude のウィンドウと同一」のときのみに変更
- **feat: Use opus alias for model and add dark-ansi theme**
  - `model` を固定バージョンからエイリアス `opus` に変更し、常に最新 Opus に追従
  - `theme: dark-ansi` を追加（Ghostty の ANSI カラーに配色を従わせる）

## 確認
- `make install ROLE=claude` で実環境とリポジトリの settings.json / notify.sh / CLAUDE.md がすべて差分なしになることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)