### PR TITLE
feat(herdr): タブ操作の指づかいをワークスペース操作へ割り当て

### DIFF
--- a/roles/herdr/.config/herdr/config.toml
+++ b/roles/herdr/.config/herdr/config.toml
@@ -18,5 +18,17 @@ split_horizontal = ["prefix+minus", "prefix+quote"]  # 既定 + prefix+'（tmux 
 cycle_pane_next = ["prefix+tab", "prefix+o"]  # 既定 + tmux: prefix + o（次のペイン）
 last_pane = "prefix+semicolon"  # tmux: prefix + ;（直前のペイン）
 
+# --- ワークスペースをタブ感覚で操作（旧タブ操作の指づかいを流用） ---
+new_workspace      = ["prefix+shift+n", "prefix+c"]  # 既定 shift+n を残しつつ prefix+c（旧: 新規タブ）でも新規ワークスペース
+next_workspace     = "prefix+n"                      # 次のワークスペース（旧: 次のタブ）
+previous_workspace = "prefix+p"                      # 前のワークスペース（旧: 前のタブ）
+switch_workspace   = "prefix+1..9"                   # 番号ジャンプ（旧: タブ番号ジャンプ）
+
+# --- 旧タブ操作を退避（衝突回避。タブは当面 shift+c での新規のみ） ---
+new_tab      = "prefix+shift+c"  # タブが欲しいときはこちら（prefix+c は new_workspace へ明け渡し）
+next_tab     = ""                # 当面無効（必要時に割当）
+previous_tab = ""                # 当面無効
+switch_tab   = ""                # 当面無効（prefix+1..9 は switch_workspace へ）
+
 [experimental]
 pane_history = false


### PR DESCRIPTION
## 概要
慣れたタブ操作のキー（`prefix+c/n/p/1..9`）で herdr の**ワークスペース**を操作できるようにします。ワークスペース名は git repo root 名で自動命名されるため、この割り当てで「サイドバー/agent 行が全部同じ repo 名になる」問題も回避できます。

## 変更（`roles/herdr/.config/herdr/config.toml` の `[keys]`）
- `new_workspace = ["prefix+shift+n", "prefix+c"]` … 既定 shift+n を残しつつ `prefix+c`（旧: 新規タブ）を追加
- `next_workspace = "prefix+n"` / `previous_workspace = "prefix+p"` … 次/前のワークスペース（旧: 次/前のタブ）
- `switch_workspace = "prefix+1..9"` … 番号ジャンプ（旧: タブ番号ジャンプ）
- 旧タブ操作を退避（衝突回避）: `new_tab = "prefix+shift+c"`、`next_tab`/`previous_tab`/`switch_tab` は無効化

## 確認
- 機密なし。既存カスタムキー（split_*/cycle_pane_next/last_pane）と非衝突。`[keys]` 重複キーなし。アクション名は herdr 0.7.4 の `--default-config` と一致。
- 反映: マージ後 `make install ROLE=herdr` → `herdr server reload-config`（再起動不要）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)