### PR TITLE
feat(zsh): リポ／グローバルの TODO を開く todo コマンドを追加

### DIFF
--- a/roles/zsh/bin/todo
+++ b/roles/zsh/bin/todo
@@ -1,0 +1,167 @@
+#!/usr/bin/env zsh
+
+# todo - open the TODO for the current context (repository or global).
+#
+# Storage layout:
+#   <git repo root>/TODO.md                      ... per-repository TODO
+#   $XDG_CONFIG_HOME/todo/TODO.md                ... global TODO (todo -g)
+#
+# During the TODO -> TODO.md migration this command also recognizes the
+# legacy extension-less "TODO" file (prefers "TODO.md" when both exist).
+# New files are always created as "TODO.md". Once every repository has
+# migrated, the legacy fallback can be dropped.
+
+set -eu
+
+TODO_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/todo"
+
+usage() {
+  cat <<EOF
+Usage: todo [command]
+
+Open the TODO for where you are.
+
+Commands:
+  (none)          Open this repository's TODO.md (anywhere inside the repo).
+                  Creates TODO.md at the repo root if it does not exist.
+  g, -g           Open the global TODO.md ($TODO_DIR/TODO.md).
+                  For TODOs that do not belong to any repository.
+  l, list, -l     List every repository's TODO plus the global one via fzf
+                  (with preview) and open the chosen file.
+  -h, --help      Show this help.
+
+Notes:
+  * 'todo' (no command) must be run inside a git repository.
+    Use 'todo -g' for the global TODO from anywhere.
+EOF
+}
+
+# Echo the TODO path to open for a given directory.
+# Prefers an existing TODO.md, then the legacy TODO, otherwise TODO.md (to create).
+resolve_todo() {
+  local dir="$1"
+  if [[ -f "$dir/TODO.md" ]]; then
+    print -r -- "$dir/TODO.md"
+  elif [[ -f "$dir/TODO" ]]; then
+    print -r -- "$dir/TODO"
+  else
+    print -r -- "$dir/TODO.md"
+  fi
+}
+
+# Echo a short label for a TODO file: "<repo-dir>/<file>", or "global/<file>"
+# for the global TODO. Uses the repo directory name (not the full path) so the
+# list stays short and does not assume any particular host/owner layout.
+label_for() {
+  local f="$1"
+  if [[ "$f" == "$TODO_DIR"/* ]]; then
+    print -r -- "global/${f:t}"
+  else
+    print -r -- "${f:h:t}/${f:t}"
+  fi
+}
+
+cmd_open() {
+  local root
+  if ! root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    print -u2 "todo: not inside a git repository. Use 'todo -g' for the global TODO."
+    return 1
+  fi
+  vim "$(resolve_todo "$root")"
+}
+
+cmd_global() {
+  mkdir -p "$TODO_DIR"
+  vim "$(resolve_todo "$TODO_DIR")"
+}
+
+cmd_list() {
+  if ! command -v fzf >/dev/null 2>&1; then
+    print -u2 "todo: 'fzf' is required for 'todo list' but was not found in PATH."
+    return 1
+  fi
+
+  # Collect existing TODO files: global first, then every ghq repository.
+  # Prefer TODO.md, but also pick up the legacy TODO (skip a repo's TODO
+  # when it already has TODO.md, so a mid-migration repo shows only once).
+  local -a files
+  files=()
+  local d f
+  for d in "$TODO_DIR"; do
+    f="$(resolve_todo "$d")"
+    [[ -f "$f" ]] && files+=("$f")
+  done
+  if command -v ghq >/dev/null 2>&1; then
+    local -a repos
+    repos=(${(f)"$(ghq list --full-path 2>/dev/null)"})
+    for d in "${repos[@]}"; do
+      f="$(resolve_todo "$d")"
+      [[ -f "$f" ]] && files+=("$f")
+    done
+  fi
+
+  if (( ${#files} == 0 )); then
+    print "No TODO files found."
+    return 0
+  fi
+
+  # Build the fzf lines here (outside the $() below), so label_for's `local`
+  # runs in this shell. Declaring `local` directly inside a command
+  # substitution makes zsh print a typeset display that pollutes fzf's input.
+  # Column 1 is the full path (used by preview and to open); column 2 is a
+  # short "<repo>/<file>" label shown to the user.
+  local -a lines
+  lines=()
+  for f in "${files[@]}"; do
+    lines+=("$f"$'\t'"$(label_for "$f")")
+  done
+
+  # Prefer bat for a colorized markdown preview (TODO files are markdown even
+  # without a .md extension); fall back to cat when bat is unavailable.
+  # The theme follows the user's global bat config (managed in dotfiles).
+  local preview_cmd='cat {1}'
+  if command -v bat >/dev/null 2>&1; then
+    preview_cmd='bat --style=plain --color=always --language=markdown --paging=never {1}'
+  fi
+
+  local selected
+  selected=$(
+    printf '%s\n' "${lines[@]}" | fzf \
+      --layout=reverse \
+      --delimiter=$'\t' \
+      --with-nth=2 \
+      --preview="$preview_cmd" \
+      --preview-window=right:60%:wrap
+  )
+
+  [[ -z "$selected" ]] && return 0
+
+  local target="${selected%%$'\t'*}"
+  vim "$target"
+}
+
+main() {
+  if (( $# == 0 )); then
+    cmd_open
+    return
+  fi
+
+  case "$1" in
+    g|-g|--global)
+      cmd_global
+      ;;
+    l|list|-l|--list)
+      cmd_list
+      ;;
+    -h|--help|help)
+      usage
+      ;;
+    *)
+      print -u2 "todo: unknown command: $1"
+      usage >&2
+      return 1
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## 概要
メモ (`note`) から TODO を分離するため、`note` と同じ体系の `todo` コマンドを新設します。`roles/zsh/bin/todo` の 1 ファイル追加のみ（`~/bin` へ install される）。

## コマンド
| 打ち方 | 動作 |
|---|---|
| `todo` | リポ直下の TODO を開く（リポ内どこからでも。無ければ `TODO.md` を新規作成） |
| `todo g` / `-g` | グローバル TODO（`~/.config/todo/TODO.md`）を開く |
| `todo l` / `list` / `-l` | 全 ghq リポ + グローバルの TODO を fzf（プレビュー付き）で一覧し、選んで開く |
| `todo -h` / `--help` | ヘルプ |

## 設計メモ
- **リポ限定**: `todo`（引数なし）は git リポ内専用。リポ外では `todo -g` を案内してエラー終了。
- **`TODO` → `TODO.md` 移行対応**: 移行期間中のため `TODO.md` を優先しつつ旧 `TODO` も認識。新規作成は常に `TODO.md`。全リポ移行後に旧 `TODO` 対応は外す予定（別 PR）。
- **プレビュー**: `bat` があれば利用（テーマはグローバル `bat` 設定に委譲。無ければ `cat`）。拡張子なしの旧 `TODO` も markdown 扱いで色付け。
- **ラベル**: `list` は `<リポ名>/<ファイル名>`（例 `dotfiles/TODO`、`global/TODO.md`）で表示。host/owner に依存しない。

## 補足
- ファイル名 `todo` は `.gitignore` の `TODO` ルール（`core.ignorecase=true`）に一致するため `git add -f` で追跡下に追加しています（一度きり。以後は通常追跡）。ignore ルールの錨付けは TODO→TODO.md 移行の別 PR で検討予定。

## テスト
- `--help` / 未知コマンドのエラー表示 ✅
- リポのサブディレクトリから引数なし → リポ直下 TODO を開く ✅
- `todo -g` → `~/.config/todo/TODO.md` を対象（ディレクトリ生成）✅
- git リポ外で `todo` → エラー + `todo -g` 案内 ✅
- `todo list` → global + 全 ghq リポの既存 TODO を収集・短縮ラベル表示 ✅
- 短縮形 `g` / `l` のルーティング ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)