### PR TITLE
feat(bat): bat を dotfiles 管理下に追加しテーマを Nord に統一

### DIFF
--- a/roles.base.lst
+++ b/roles.base.lst
@@ -1,6 +1,7 @@
 homebrew
 gnu-cmds
 ripgrep
+bat
 fzf
 git
 ghq

--- a/roles.lst
+++ b/roles.lst
@@ -1,6 +1,7 @@
 homebrew
 gnu-cmds
 ripgrep
+bat
 fzf
 git
 ghq

--- a/roles/bat/.config/bat/config
+++ b/roles/bat/.config/bat/config
@@ -1,0 +1,3 @@
+# bat の設定（dotfiles 管理）
+# テーマを Nord に統一し、他の nord 環境（dircolors など）と揃える。
+--theme="Nord"

--- a/roles/bat/README.md
+++ b/roles/bat/README.md
@@ -1,0 +1,17 @@
+# roles/bat
+sharkdp/bat: A cat(1) clone with syntax highlighting and Git integration
+
+
+
+## Dependencies
+- homebrew
+
+
+
+## Configuration
+- `~/.config/bat/config` … テーマを Nord に固定（`--theme="Nord"`）。他の nord 環境と配色を揃える。
+
+
+
+## References
+- [sharkdp/bat: A cat(1) clone with wings](https://github.com/sharkdp/bat)

--- a/roles/bat/install.sh
+++ b/roles/bat/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env zsh
+set -e
+
+readonly CURRENT_PATH=$(cd $(dirname $0); pwd)
+
+
+brew list bat > /dev/null 2>&1 || {
+  brew install bat
+}
+
+(
+cd ${CURRENT_PATH}
+cp -fr .config ${HOME}/
+)


### PR DESCRIPTION
## 概要
`bat` をこれまで dotfiles でグローバル管理しておらず、他の nord 環境（dircolors など）と配色がそろっていませんでした。`roles/bat` を新設し、`~/.config/bat/config` で `--theme="Nord"` を配布してテーマを統一します。

## 変更
- `roles/bat/install.sh` … `brew install bat`（未導入時）＋ `.config` を `$HOME/` へ配布（ghostty role と同じ流儀）。
- `roles/bat/.config/bat/config` … `--theme="Nord"`。
- `roles/bat/README.md` … 既存 role の README 書式に準拠。
- `roles.base.lst` / `roles.lst` … `bat` を追加（`make install`（`ROLE=` 無し一括）の対象に含める。並びは sharkdp 系の `ripgrep` 直後）。

## 効果
- `bat` 全体が Nord になる。
- `todo list` のプレビューは `bat` を `--theme` 無しで呼んでいるため、この config 経由で自動的に Nord を継承する（先の todo PR で todo 側の `--theme=Nord` 固定は撤去済み）。

## テスト
- `zsh roles/bat/install.sh` 実行 → `~/.config/bat/config` が配布される ✅
- `--theme` を付けずに `bat` を実行 → config 経由で Nord 配色（`##` が frost 色）を適用 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)