### PR TITLE
feat(zsh): todo list に worktree の TODO を動的列挙

### DIFF
--- a/roles/zsh/bin/todo
+++ b/roles/zsh/bin/todo
@@ -49,18 +49,6 @@ resolve_todo() {
   fi
 }
 
-# Echo a short label for a TODO file: "<repo-dir>/<file>", or "global/<file>"
-# for the global TODO. Uses the repo directory name (not the full path) so the
-# list stays short and does not assume any particular host/owner layout.
-label_for() {
-  local f="$1"
-  if [[ "$f" == "$TODO_DIR"/* ]]; then
-    print -r -- "global/${f:t}"
-  else
-    print -r -- "${f:h:t}/${f:t}"
-  fi
-}
-
 cmd_open() {
   local root
   if ! root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
@@ -81,40 +69,63 @@ cmd_list() {
     return 1
   fi
 
-  # Collect existing TODO files: global first, then every ghq repository.
-  # Prefer TODO.md, but also pick up the legacy TODO (skip a repo's TODO
-  # when it already has TODO.md, so a mid-migration repo shows only once).
-  local -a files
-  files=()
-  local d f
-  for d in "$TODO_DIR"; do
-    f="$(resolve_todo "$d")"
-    [[ -f "$f" ]] && files+=("$f")
-  done
+  # Build the fzf lines directly as "<full-path>\t<label>".
+  # Column 1 (full path) is used by the preview and to open the file; column 2
+  # is a short label shown to the user. Building the lines here (not inside the
+  # $() below) keeps the label logic in this shell: declaring `local` directly
+  # inside a command substitution makes zsh print a typeset display that would
+  # pollute fzf's input.
+  local -a lines
+  lines=()
+  local f
+
+  # Global TODO first.
+  f="$(resolve_todo "$TODO_DIR")"
+  [[ -f "$f" ]] && lines+=("$f"$'\t'"global/${f:t}")
+
+  # Every ghq repository, plus each repository's linked worktrees.
   if command -v ghq >/dev/null 2>&1; then
     local -a repos
     repos=(${(f)"$(ghq list --full-path 2>/dev/null)"})
-    for d in "${repos[@]}"; do
-      f="$(resolve_todo "$d")"
-      [[ -f "$f" ]] && files+=("$f")
+    local repo name wt br line
+    for repo in "${repos[@]}"; do
+      name="${repo:t}"
+
+      # The repository's own TODO (main worktree).
+      f="$(resolve_todo "$repo")"
+      [[ -f "$f" ]] && lines+=("$f"$'\t'"${name}/${f:t}")
+
+      # Linked worktrees of this repo (herdr keeps them under ~/.herdr/worktrees,
+      # outside the ghq root, so they are not covered by the ghq scan above).
+      # Parse `git worktree list --porcelain`: blank-line-separated records with
+      # "worktree <path>" and "branch refs/heads/<name>" lines. Skip the main
+      # worktree (path == repo) to avoid duplicating the entry added above.
+      wt=""; br=""
+      while IFS= read -r line; do
+        case "$line" in
+          "worktree "*) wt="${line#worktree }" ;;
+          "branch refs/heads/"*) br="${line#branch refs/heads/}" ;;
+          "")
+            if [[ -n "$wt" && "$wt" != "$repo" ]]; then
+              f="$(resolve_todo "$wt")"
+              [[ -f "$f" ]] && lines+=("$f"$'\t'"${name}@${br:-detached}/${f:t}")
+            fi
+            wt=""; br=""
+            ;;
+        esac
+      done < <(git -C "$repo" worktree list --porcelain 2>/dev/null)
+      # The last record may not be followed by a trailing blank line.
+      if [[ -n "$wt" && "$wt" != "$repo" ]]; then
+        f="$(resolve_todo "$wt")"
+        [[ -f "$f" ]] && lines+=("$f"$'\t'"${name}@${br:-detached}/${f:t}")
+      fi
     done
   fi
 
-  if (( ${#files} == 0 )); then
+  if (( ${#lines} == 0 )); then
     print "No TODO files found."
     return 0
   fi
-
-  # Build the fzf lines here (outside the $() below), so label_for's `local`
-  # runs in this shell. Declaring `local` directly inside a command
-  # substitution makes zsh print a typeset display that pollutes fzf's input.
-  # Column 1 is the full path (used by preview and to open); column 2 is a
-  # short "<repo>/<file>" label shown to the user.
-  local -a lines
-  lines=()
-  for f in "${files[@]}"; do
-    lines+=("$f"$'\t'"$(label_for "$f")")
-  done
 
   # Prefer bat for a colorized markdown preview (TODO files are markdown even
   # without a .md extension); fall back to cat when bat is unavailable.


### PR DESCRIPTION
## 概要
`todo list` で、各リポの worktree に置いた TODO も辿れるようにします。herdr の worktree は `~/.herdr/worktrees/`（ghq root の外）に作られ、`ghq list` の走査に入らないため、これまで `todo list` に出ませんでした。

## 方式（調査の結論）
- **ghq 登録方式は不採用**：`ghq migrate` は worktree の実体を ghq root へ**移動**し、herdr の worktree 追跡（`~/.herdr/worktrees`）を壊すため。外部ディレクトリを移動なしで登録するコマンドは ghq に無い。symlink を張れば `ghq list` に載る（実測）が、ghq の非公式挙動への依存になるため見送り。
- **採用：`git worktree list --porcelain` の動的展開**。各 ghq リポに対し worktree を列挙し、リンク worktree の TODO も加える。**git 標準のみ・状態管理不要・worktree スキルの改造不要**。

## 変更（`roles/zsh/bin/todo` のみ）
- `cmd_list`：ghq 各リポで `git worktree list --porcelain` を展開し、worktree の TODO を列挙。
- ラベル：worktree は `repo@branch/<file>`、リポ本体は `repo/<file>`、global は `global/<file>`。
- メイン worktree（= リポ本体パス）は重複除外。
- ラベル整形を各 source 内にインライン化し、不要になった `label_for` を削除。

## テスト
- 一時 worktree（TODO.md 付き）を ghq root 外に作成 → `todo list` の収集が `dotfiles@tmp-todo-test/TODO.md` として列挙、本体 `dotfiles/TODO` と重複しないことを確認 ✅（検証後、worktree・branch は掃除済み）
- worktree が無いリポは従来どおり本体のみ列挙・エラーなし ✅
- `zsh -n` 構文チェック ✅

## 補足
- 独立 PR（bat 設定 PR #132 とは分離）。`git worktree list` のみに依存し ghq の非公式挙動には依存しません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)