### PR TITLE
feat(node): node を導入する roles/node を追加（npm/npx 同梱）

### DIFF
--- a/roles.base.lst
+++ b/roles.base.lst
@@ -10,6 +10,7 @@ nvim
 tmux
 herdr
 gh
+node
 tig
 tree
 jq

--- a/roles.lst
+++ b/roles.lst
@@ -10,6 +10,7 @@ nvim
 tmux
 herdr
 gh
+node
 tig
 tree
 jq

--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -1,0 +1,18 @@
+# roles/node
+Node.js: JavaScript runtime (npm / npx bundled)
+
+
+
+## Dependencies
+- homebrew
+
+
+
+## Notes
+- Homebrew の素の node を入れる（npm・npx が同梱される）。`npx <pkg>` で npm 製 CLI をアドホックに実行できる。
+- プロジェクトごとに node バージョンを固定したくなったら、mise / fnm などのバージョン管理へ移行する（その場合はこの role を差し替える）。
+
+
+
+## References
+- [Node.js](https://nodejs.org/)

--- a/roles/node/install.sh
+++ b/roles/node/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+set -e
+
+
+brew list node > /dev/null 2>&1 || {
+  brew install node
+}


### PR DESCRIPTION
## 概要
`npx` で npm 製 CLI（`defuddle` 等）をアドホック実行したいが、この Mac には node/npm/npx が一切ありませんでした。Homebrew の素の node を入れる `roles/node` を新設します。

## 設計判断
- **素の node（`brew install node`）** を採用。用途が「アドホックな `npx <pkg>`」「node 前提ツール（gh skill 等）の実行」で、**プロジェクト別のバージョン切り替えは不要**なため、mise/fnm/nvm のバージョン管理は入れません。既存 role（fd/ripgrep 等）と同じ brew install 流儀に統一。必要になれば後から差し替え可能。
- **base** に分類（npx を汎用ユーティリティとして常に入れたい。`gh` が base にいるのと同じ扱い）。

## 変更
- `roles/node/install.sh` … `brew install node`（未導入時）。
- `roles/node/README.md` … 既存 role の書式に準拠＋方針メモ。
- `roles.base.lst` / `roles.lst` … `gh` の直後に `node` を追加（`make install` 一括の対象）。整合性 `base+dev+etc == roles.lst` を確認。

## テスト
- `zsh roles/node/install.sh` 実行 → node v26.5.0 / npm 11.17.0 / npx 11.17.0 導入 ✅
- `npx --yes cowsay` がアドホック実行できることを確認（npm 製 CLI が npx で動く）✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)