### PR TITLE
fix(zsh): todo / note を nvim で開く（vim だと設定が効かない）

### DIFF
--- a/roles/zsh/bin/note
+++ b/roles/zsh/bin/note
@@ -19,7 +19,7 @@ Usage: note [command]
 A simple note-taking command.
 
 Commands:
-  (none)        Open \$XDG_CONFIG_HOME/note/NOTE.md in vim (creates if missing).
+  (none)        Open \$XDG_CONFIG_HOME/note/NOTE.md in nvim (creates if missing).
   new           Archive current NOTE.md, then open a fresh NOTE.md.
                 Archive path: \$XDG_CONFIG_HOME/note/archives/NOTE.YYYYMMDD-HHMMSS.md
   list          List archived notes via fzf (with preview) and open the chosen one.
@@ -30,7 +30,7 @@ EOF
 
 cmd_open() {
   mkdir -p "$NOTE_DIR"
-  vim "$NOTE_FILE"
+  nvim "$NOTE_FILE"
 }
 
 cmd_new() {
@@ -40,7 +40,7 @@ cmd_new() {
     ts="$(date +%Y%m%d-%H%M%S)"
     mv "$NOTE_FILE" "$ARCHIVE_DIR/NOTE.${ts}.md"
   fi
-  vim "$NOTE_FILE"
+  nvim "$NOTE_FILE"
 }
 
 cmd_list() {
@@ -82,7 +82,7 @@ cmd_list() {
   [[ -z "$selected" ]] && return 0
 
   local fname="${selected%%$'\t'*}"
-  vim "$ARCHIVE_DIR/$fname"
+  nvim "$ARCHIVE_DIR/$fname"
 }
 
 cmd_browse() {

--- a/roles/zsh/bin/todo
+++ b/roles/zsh/bin/todo
@@ -55,12 +55,12 @@ cmd_open() {
     print -u2 "todo: not inside a git repository. Use 'todo -g' for the global TODO."
     return 1
   fi
-  vim "$(resolve_todo "$root")"
+  nvim "$(resolve_todo "$root")"
 }
 
 cmd_global() {
   mkdir -p "$TODO_DIR"
-  vim "$(resolve_todo "$TODO_DIR")"
+  nvim "$(resolve_todo "$TODO_DIR")"
 }
 
 cmd_list() {
@@ -148,7 +148,7 @@ cmd_list() {
   [[ -z "$selected" ]] && return 0
 
   local target="${selected%%$'\t'*}"
-  vim "$target"
+  nvim "$target"
 }
 
 main() {


### PR DESCRIPTION
## 概要
`todo` / `note` が開くエディタが nvim ではなく本物の Vim だった問題を修正します。

## 原因
両スクリプトは起動エディタを `vim` とハードコードしていました。しかしスクリプト（非対話 zsh）では対話シェルの `alias vim='nvim'` が効かず、`vim` は PATH の実体 `/usr/bin/vim`（= 本物の Vim 9.1、macOS 同梱）に解決されていました。

そのため `todo` / `todo list` / `note` で開くと、**nvim の設定（nord・markdown ハイライト・自作キーバインド）が一切効かない**状態でした（TODO 項目「todo l で vim ハイライトが効かない」の原因）。

## 変更
- `roles/zsh/bin/todo` の `vim` 呼び出し 3 箇所 → `nvim`
- `roles/zsh/bin/note` の `vim` 呼び出し 3 箇所 → `nvim`（＋ usage 文言の "in vim" → "in nvim"）

## テスト
- 非対話 zsh で `nvim` が `/opt/homebrew/bin/nvim`（v0.12.1）に解決されることを確認 ✅
- `zsh -n` 構文チェック ✅
- 残存する単独 `vim` 参照が無いことを確認 ✅
- live（`~/bin/todo`, `~/bin/note`）へ反映済み

## 補足
- これは TODO→TODO.md 移行の「## の色が直る」副次効果の前提でもある（nvim で開かないと markdown ハイライトが効かないため）。移行本体とは独立した単独修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)