### PR TITLE
chore(gitignore): TODO.md / DONE.md を ignore に追加（移行の地ならし）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,11 @@ Temporary Items
 .apdisk
 
 # dotfiles
-TODO.txt
+# TODO 運用のワーキングファイル。TODO/TODO-DONE から TODO.md/DONE.md へ移行中のため両対応。
 TODO
+TODO.md
 TODO-DONE
+DONE.md
 
 # Claude
 .claude/**/*.bak*

--- a/roles/git/.gitignore_ownrule
+++ b/roles/git/.gitignore_ownrule
@@ -5,6 +5,9 @@
 
 # TODO 運用のワーキングファイル（未完了リスト / 完了履歴）は個人用のため追跡しない
 # ※ リポジトリで TODO を追跡したいプロンプトの場合は git add -f で個別に追加する
+# TODO/TODO-DONE から TODO.md/DONE.md へ移行中のため両対応（移行完了後に旧名を削除）
 TODO
+TODO.md
 TODO-DONE
+DONE.md
 


### PR DESCRIPTION
## 概要
`TODO`/`TODO-DONE` → `TODO.md`/`DONE.md` 移行の前準備（S1）。実ファイルの rename より前に、新名 `TODO.md` / `DONE.md` を ignore に追加しておく（rename しても追跡候補に出ないように）。

## 変更
- repo `.gitignore` と配布元 `roles/git/.gitignore_ownrule` の両方に `TODO.md` / `DONE.md` を追加。
- 旧 `TODO` / `TODO-DONE` は移行中のため残す（全リポ移行後に別 PR で削除予定）。
- 使われていない `TODO.txt` エントリを削除。

## 確認
- `TODO` / `TODO-DONE` / `TODO.md` / `DONE.md` すべて ignore されることを確認済み（現行の dotfiles TODO 追跡は維持）。

## 補足
- live の global gitignore（`~/.config/git/.gitignore_global`）への反映は `make install ROLE=git`（別途・ユーザー実行）。この PR 自体は repo 側の定義変更のみ。
- 実ファイルの rename は claude 側のフック `.md` 対応（TODO 注入が止まらないための前提）が済んでから。

🤖 Generated with [Claude Code](https://claude.com/claude-code)