### PR TITLE
feat: obsidian role を追加、claude role に Claude デスクトップ App を追加

### DIFF
--- a/roles.lst
+++ b/roles.lst
@@ -31,6 +31,7 @@ colima
 devbox
 claude
 vscode
+obsidian
 github-actions
 1password
 tradingview

--- a/roles/claude/install.sh
+++ b/roles/claude/install.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env zsh
 set -e
 
-# Claude Code (CLI) 本体のインストールのみを担当する。
+# Claude Code (CLI) 本体と Claude デスクトップ App のインストールを担当する。
 # ~/.claude の設定（CLAUDE.md / settings.json / skills / hooks 等）は
 # 別リポジトリ onigomex/claude で管理する。
 
+# Claude Code (CLI)
 brew list --cask claude-code > /dev/null 2>&1 || {
   brew install claude-code --cask
 }
 
+# Claude Desktop App
+brew list --cask claude > /dev/null 2>&1 || {
+  brew install claude --cask
+}
+
 cat <<'MSG'
-[claude] Claude Code (CLI) のインストールは完了しました。
+[claude] Claude Code (CLI) と Claude デスクトップ App のインストールは完了しました。
 [claude] ~/.claude の設定は別リポジトリ onigomex/claude で管理しています。
 [claude] 設定を反映するには onigomex/claude を clone し、`make update` を実行してください。
 [claude]   https://github.com/onigomex/claude

--- a/roles/obsidian/README.md
+++ b/roles/obsidian/README.md
@@ -1,0 +1,12 @@
+# roles/obsidian
+Obsidian: Knowledge base that works on top of a local folder of plain text Markdown files
+
+
+
+## Dependencies
+- homebrew
+
+
+
+## References
+- [Obsidian](https://obsidian.md/)

--- a/roles/obsidian/install.sh
+++ b/roles/obsidian/install.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+set -e
+
+
+brew list --cask obsidian > /dev/null 2>&1 || {
+  brew install obsidian --cask
+}


### PR DESCRIPTION
## 概要
- **Obsidian** を新規 role として追加（`brew install --cask obsidian`）。
- 既存 **`roles/claude`** に **Claude デスクトップ App**（`brew install --cask claude`）を追加。従来の `claude-code`（CLI）に加え、デスクトップ App も入れる。

## 変更
- `roles/obsidian/`（install.sh / README.md）を新設。
- `roles.lst` に `obsidian` を追加（`vscode` の次）。
- `roles/claude/install.sh` に Claude デスクトップ App の cask install を追加＋完了メッセージを更新。

## 確認
- cask 名を brew で確認済み（`claude`=Anthropic 公式デスクトップ App、`obsidian`）。
- `zsh -n` 構文チェック OK。install.sh は既存 role に合わせ 644。

## 補足
- 実際のインストールは `make install ROLE=obsidian` / `make install ROLE=claude`（GUI App のため自動実行はしていません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)