### PR TITLE
refactor: TODO→TODO.md 移行の仕上げ（旧名フォールバックと ignore を削除）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,8 @@ Temporary Items
 .apdisk
 
 # dotfiles
-# TODO 運用のワーキングファイル。TODO/TODO-DONE から TODO.md/DONE.md へ移行中のため両対応。
-TODO
+# TODO 運用のワーキングファイル（未完了リスト / 完了履歴）は個人用のため追跡しない
 TODO.md
-TODO-DONE
 DONE.md
 
 # Claude

--- a/roles/git/.gitignore_ownrule
+++ b/roles/git/.gitignore_ownrule
@@ -5,9 +5,6 @@
 
 # TODO 運用のワーキングファイル（未完了リスト / 完了履歴）は個人用のため追跡しない
 # ※ リポジトリで TODO を追跡したいプロンプトの場合は git add -f で個別に追加する
-# TODO/TODO-DONE から TODO.md/DONE.md へ移行中のため両対応（移行完了後に旧名を削除）
-TODO
 TODO.md
-TODO-DONE
 DONE.md
 

--- a/roles/zsh/bin/todo
+++ b/roles/zsh/bin/todo
@@ -5,11 +5,6 @@
 # Storage layout:
 #   <git repo root>/TODO.md                      ... per-repository TODO
 #   $XDG_CONFIG_HOME/todo/TODO.md                ... global TODO (todo -g)
-#
-# During the TODO -> TODO.md migration this command also recognizes the
-# legacy extension-less "TODO" file (prefers "TODO.md" when both exist).
-# New files are always created as "TODO.md". Once every repository has
-# migrated, the legacy fallback can be dropped.
 
 set -eu
 
@@ -36,17 +31,9 @@ Notes:
 EOF
 }
 
-# Echo the TODO path to open for a given directory.
-# Prefers an existing TODO.md, then the legacy TODO, otherwise TODO.md (to create).
+# Echo the TODO path for a given directory (created on open if missing).
 resolve_todo() {
-  local dir="$1"
-  if [[ -f "$dir/TODO.md" ]]; then
-    print -r -- "$dir/TODO.md"
-  elif [[ -f "$dir/TODO" ]]; then
-    print -r -- "$dir/TODO"
-  else
-    print -r -- "$dir/TODO.md"
-  fi
+  print -r -- "$1/TODO.md"
 }
 
 cmd_open() {
@@ -127,8 +114,8 @@ cmd_list() {
     return 0
   fi
 
-  # Prefer bat for a colorized markdown preview (TODO files are markdown even
-  # without a .md extension); fall back to cat when bat is unavailable.
+  # Prefer bat for a colorized markdown preview; fall back to cat when bat is
+  # unavailable.
   # The theme follows the user's global bat config (managed in dotfiles).
   local preview_cmd='cat {1}'
   if command -v bat >/dev/null 2>&1; then


### PR DESCRIPTION
## 概要
TODO→TODO.md 移行の**仕上げ**。全リポ（claude / dotfiles / tradingview / home）で TODO/DONE の実ファイルが `TODO.md`/`DONE.md` へ移行済みになったので、移行用スキャフォールドを撤去する。

## 変更
- **roles/zsh/bin/todo**: `resolve_todo` の旧 `TODO`（拡張子なし）フォールバックを削除し、常に `TODO.md` を返すよう簡素化。移行説明コメントも除去。呼び出し側は無変更。
- **.gitignore / roles/git/.gitignore_ownrule**: 旧名 `TODO` / `TODO-DONE` の ignore 行を削除（`TODO.md` / `DONE.md` のみ残す）。

## 安全性
- 事前に全 ghq リポを走査し、拡張子なし `TODO`/`TODO-DONE` の残存が無いことを確認済み → フォールバックは既に発火しないため**挙動不変**。
- claude フック（inject/check・別リポ）は既に `.md` 優先で、本 PR とは独立。
- `zsh -n` 構文チェック OK。

## マージ後の作業（別ステップ）
- ライブ反映: `make install ROLE=zsh`（todo ツール）/ `make install ROLE=git`（gitignore ownrule）。
- ※ dotfiles 自身の実ファイル rename（`TODO`→`TODO.md` / `TODO-DONE`→`DONE.md`）は本 PR 対象外（gitignore 済みのローカルファイル・実施済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)