### PR TITLE
feat(hammerspoon): Preferences > Behavior をコードで固定

### DIFF
--- a/roles/hammerspoon/.hammerspoon/init.lua
+++ b/roles/hammerspoon/.hammerspoon/init.lua
@@ -14,6 +14,15 @@ hs.pathwatcher.new(os.getenv("HOME") .. "/.hammerspoon/", reloadConfig):start()
 hs.notify.new({title="Hammerspoon", informativeText="Config loaded"}):send()
 
 
+-- Preferences > Behavior（GUI のチェック状態をコードで固定・冪等）
+hs.autoLaunch(true)                     -- Launch Hammerspoon at login: ON
+hs.automaticallyCheckForUpdates(true)   -- Check for updates: ON
+hs.dockIcon(false)                      -- Show dock icon: OFF
+hs.menuIcon(true)                       -- Show menu icon: ON
+hs.consoleOnTop(false)                  -- Keep Console window on top: OFF
+hs.uploadCrashData(false)               -- Send crash data: OFF
+
+
 -- Toggle Application
 local previous_app = nil
 local cmd_shift = {"cmd", "shift"}

--- a/roles/hammerspoon/README.md
+++ b/roles/hammerspoon/README.md
@@ -1,28 +1,44 @@
 # roles/hammerspoon
-Hammerspoon/hammerspoon: Staggeringly powerful macOS desktop automation with Lua
+Hammerspoon（Lua による macOS デスクトップ自動化）を導入し、設定（`.hammerspoon/`）を配布する role。
 
-
-
-## Dependencies
+## 依存
 - homebrew
 
+## 環境設定（Preferences > Behavior）
+Hammerspoon 環境設定の Behavior パネルは、`init.lua` で Lua API により宣言的に設定している（起動の度に実行＝冪等・まっさらな Mac でも再現）。
 
+| 項目 | 状態 | コード（init.lua） |
+|---|---|---|
+| Launch Hammerspoon at login | ON | `hs.autoLaunch(true)` |
+| Check for updates | ON | `hs.automaticallyCheckForUpdates(true)` |
+| Show dock icon | OFF | `hs.dockIcon(false)` |
+| Show menu icon | ON | `hs.menuIcon(true)` |
+| Keep Console window on top | OFF | `hs.consoleOnTop(false)` |
+| Send crash data | OFF | `hs.uploadCrashData(false)` |
 
-## Preferences
-- Behavior:
-  - Launch Hammerspoon at login
-  - Check for updates
-  - Show menu icon
-- Accessibility:
-  - Enable Accessibility
+## プラグイン（Spoons）
+Hammerspoon のプラグインは **Spoon** と呼ばれる形式（`~/.hammerspoon/Spoons/*.spoon`）。この role では Spoon を **SpoonInstall** で宣言的に管理する。
 
+- **SpoonInstall とは**: Spoon をインストール／管理するための Spoon（作者 Diego Zamboni・MIT）。Hammerspoon 本体には Spoon のパッケージ管理機構が無く、その空白を埋める事実上の標準。公式リポジトリ `Hammerspoon/Spoons` に同梱され、公式 Spoons ページにも掲載される（コミュニティ製だが公式配布）。
+- **管理方式**: `SpoonInstall.spoon` だけを repo に同梱（vendor）し、`Spoons/.gitignore` で他の Spoon は追跡しない。各 Spoon は `init.lua` で `spoon.SpoonInstall:andUse("Name", {…})` と宣言すると、公式リポジトリから自動取得＋設定＋hotkey＋起動まで一括で行われる。Spoon を増やすのは `andUse` を1行足すだけで、`install.sh` は触らない。
 
+### Caffeine（スリープ防止）
+Mac の自動スリープ（ディスプレイ／システム）を抑止する Spoon。SpoonInstall の `andUse` で導入し、起動時にオンにする。メニューバーのアイコン、または hyper+F6 でトグルできる。
 
-## System Settings
-- System Settings > Privacy & Security > Accessibility > Enable
+## Accessibility（コード化不可・手動）
+`System Settings > Privacy & Security > Accessibility` で Hammerspoon を**手動で ON** にする必要がある。イベントタップ（En/Ja 切替やホットキー）に必須。
 
+- **なぜコードで ON にできないか**: Accessibility 許可は macOS の TCC（透明性・同意・制御）が管理し、その許可 DB は SIP で保護されている。そのため `defaults` や CLI からの付与はできず（`tccutil` で可能なのは取り消し=reset のみ）、付与にはユーザーの明示的なダイアログ承認が必要。MDM の PPPC プロファイルなら付与可能だが、個人（非 MDM）の Mac では手動が唯一の手段。
+- 補足: `init.lua` で `hs.accessibilityState(true)` を呼ぶと許可ダイアログを prompt できるが、最終的な「許可」クリックは手動。
 
+## 手動セットアップ手順（残る手作業）
+1. 初回起動後、`System Settings > Privacy & Security > Accessibility` で Hammerspoon を ON にする（上記の理由によりコード化不可）。
 
 ## References
 - [Hammerspoon/hammerspoon: Staggeringly powerful macOS desktop automation with Lua](https://github.com/Hammerspoon/hammerspoon)
-
+- [Hammerspoon docs（hs モジュール: autoLaunch / automaticallyCheckForUpdates / dockIcon / menuIcon / consoleOnTop / uploadCrashData / accessibilityState）](https://www.hammerspoon.org/docs/hs.html)
+- [Hammerspoon Spoons（プラグイン一覧）](https://www.hammerspoon.org/Spoons/)
+- [SpoonInstall（Spoon の宣言的管理・de-facto 標準）](https://www.hammerspoon.org/Spoons/SpoonInstall.html)
+- [zzamboni: Using Spoons in Hammerspoon](https://zzamboni.org/post/using-spoons-in-hammerspoon/)
+- [Caffeine.spoon](https://www.hammerspoon.org/Spoons/Caffeine.html)
+- [Hammerspoon FAQ（Accessibility 権限まわり）](https://www.hammerspoon.org/faq/)


### PR DESCRIPTION
## 概要
wiki「インストール後設定」の Hammerspoon 手順（手動チェック）をコード化。`init.lua` に Hammerspoon コアの Lua API を追加し、Preferences > Behavior の各項目を**宣言的・冪等**に設定する。起動の度に `init.lua` が走るため、まっさらな Mac でもログイン項目含め再現する。

ゴール（ユーザー提示の設定画面）と対応:
| Behavior | 目標 | コード |
|---|---|---|
| Launch Hammerspoon at login | ✅ | `hs.autoLaunch(true)` |
| Check for updates | ✅ | `hs.automaticallyCheckForUpdates(true)` |
| Show dock icon | ⬜ | `hs.dockIcon(false)` |
| Show menu icon | ✅ | `hs.menuIcon(true)` |
| Keep Console window on top | ⬜ | `hs.consoleOnTop(false)` |
| Send crash data | ⬜ | `hs.uploadCrashData(false)` |

## 裏取り
- 6関数はいずれも Hammerspoon コア `hs` モジュールに実在（[docs](https://www.hammerspoon.org/docs/hs.html)）。
- 実機 defaults とも整合: `HSUploadCrashData=0`（crash OFF）、`SUEnableAutomaticChecks=1`（更新確認 ON）。
- setter を毎起動で呼ぶだけ＝冪等。

## 補足
- 「自動電源OFF（スリープ抑止）」は既存の Caffeine spoon（`spoon.Caffeine:clicked()`）で対応済みのため本 PR では触れない。
- ライブ反映はマージ後 `make install ROLE=hammerspoon`（`.hammerspoon` を $HOME へ配布）で。

🤖 Generated with [Claude Code](https://claude.com/claude-code)