### PR TITLE
chore(hammerspoon): アプリ トグルの対象を WezTerm→Ghostty に切替

### DIFF
--- a/roles/hammerspoon/.hammerspoon/config/app_toggle.lua
+++ b/roles/hammerspoon/.hammerspoon/config/app_toggle.lua
@@ -29,5 +29,5 @@ function toggle_application(_app)
 end
 -- keymap: Console > hs.inspect(hs.keycodes.map)
 -- smei_colon:41, dot:47, comma:43, lightcmd:54
-hs.hotkey.bind(cmd_shift, 41, function() toggle_application("WezTerm") end)
-hs.hotkey.bind(cmd_shift, 47, function() toggle_application("Google Chrome") end)
+hs.hotkey.bind(cmd_shift, 41, function() toggle_application("Ghostty") end)       -- ⌘⇧; (セミコロン)
+hs.hotkey.bind(cmd_shift, 47, function() toggle_application("Google Chrome") end) -- ⌘⇧. (ピリオド)


### PR DESCRIPTION
## 概要
`config/app_toggle.lua` の cmd+shift+:（キーコード41）のトグル対象を、移行済みの端末 **Ghostty** に差し替える。キーバインド・ロジックは変更せず、アプリ名のみ（`/Applications/Ghostty.app` を確認済み）。

Ghostty→Chrome の残骸掃除のうち「アプリトグル対象」分。install.sh の Terminal 向け defaults 等の残りは別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)