### PR TITLE
feat(hammerspoon): Spoon 管理を SpoonInstall に移行（curl 廃止）

### DIFF
--- a/roles/hammerspoon/.hammerspoon/Spoons/.gitignore
+++ b/roles/hammerspoon/.hammerspoon/Spoons/.gitignore
@@ -1,0 +1,5 @@
+# Spoon は実行時に SpoonInstall が公式リポジトリから取得するため追跡しない。
+# 管理者スプーンである SpoonInstall.spoon だけを vendor（コミット）する。
+/*
+!/.gitignore
+!/SpoonInstall.spoon/

--- a/roles/hammerspoon/.hammerspoon/Spoons/SpoonInstall.spoon/docs.json
+++ b/roles/hammerspoon/.hammerspoon/Spoons/SpoonInstall.spoon/docs.json
@@ -1,0 +1,478 @@
+[
+  {
+    "Command": [],
+    "Constant": [],
+    "Constructor": [],
+    "Deprecated": [],
+    "Field": [],
+    "Function": [],
+    "Method": [
+      {
+        "def": "SpoonInstall:andUse(name, arg)",
+        "desc": "Declaratively install, load and configure a Spoon",
+        "doc": "Declaratively install, load and configure a Spoon\n\nParameters:\n * name - the name of the Spoon to install (without the `.spoon` extension). If the Spoon is already installed, it will be loaded using `hs.loadSpoon()`. If it is not installed, it will be installed using `SpoonInstall:asyncInstallSpoonFromRepo()` and then loaded.\n * arg - if provided, can be used to specify the configuration of the Spoon. The following keys are recognized (all are optional):\n   * repo - repository from where the Spoon should be installed if not present in the system, as defined in `SpoonInstall.repos`. Defaults to `\"default\"`.\n   * config - a table containing variables to be stored in the Spoon object to configure it. For example, `config = { answer = 42 }` will result in `spoon.<LoadedSpoon>.answer` being set to 42.\n   * hotkeys - a table containing hotkey bindings. If provided, will be passed as-is to the Spoon's `bindHotkeys()` method. The special string `\"default\"` can be given to use the Spoons `defaultHotkeys` variable, if it exists.\n   * fn - a function which will be called with the freshly-loaded Spoon object as its first argument.\n   * loglevel - if the Spoon has a variable called `logger`, its `setLogLevel()` method will be called with this value.\n   * start - if `true`, call the Spoon's `start()` method after configuring everything else.\n   * disable - if `true`, do nothing. Easier than commenting it out when you want to temporarily disable a spoon.\n\nReturns:\n * None",
+        "name": "andUse",
+        "parameters": [
+          " * name - the name of the Spoon to install (without the `.spoon` extension). If the Spoon is already installed, it will be loaded using `hs.loadSpoon()`. If it is not installed, it will be installed using `SpoonInstall:asyncInstallSpoonFromRepo()` and then loaded.",
+          " * arg - if provided, can be used to specify the configuration of the Spoon. The following keys are recognized (all are optional):",
+          "   * repo - repository from where the Spoon should be installed if not present in the system, as defined in `SpoonInstall.repos`. Defaults to `\"default\"`.",
+          "   * config - a table containing variables to be stored in the Spoon object to configure it. For example, `config = { answer = 42 }` will result in `spoon.<LoadedSpoon>.answer` being set to 42.",
+          "   * hotkeys - a table containing hotkey bindings. If provided, will be passed as-is to the Spoon's `bindHotkeys()` method. The special string `\"default\"` can be given to use the Spoons `defaultHotkeys` variable, if it exists.",
+          "   * fn - a function which will be called with the freshly-loaded Spoon object as its first argument.",
+          "   * loglevel - if the Spoon has a variable called `logger`, its `setLogLevel()` method will be called with this value.",
+          "   * start - if `true`, call the Spoon's `start()` method after configuring everything else.",
+          "   * disable - if `true`, do nothing. Easier than commenting it out when you want to temporarily disable a spoon."
+        ],
+        "returns": [
+          " * None"
+        ],
+        "signature": "SpoonInstall:andUse(name, arg)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:asyncInstallSpoonFromRepo(name, repo, callback)",
+        "desc": "Asynchronously install a Spoon from a registered repository",
+        "doc": "Asynchronously install a Spoon from a registered repository\n\nParameters:\n * name - Name of the Spoon to install.\n * repo - Name of the repository to use. Defaults to `\"default\"`\n * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:\n   * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file\n   * success - boolean indicating whether the installation was successful\n\nReturns:\n * `true` if the installation was correctly initiated (i.e. the repo and spoon name were correct), `false` otherwise.",
+        "name": "asyncInstallSpoonFromRepo",
+        "parameters": [
+          " * name - Name of the Spoon to install.",
+          " * repo - Name of the repository to use. Defaults to `\"default\"`",
+          " * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:",
+          "   * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file",
+          "   * success - boolean indicating whether the installation was successful"
+        ],
+        "returns": [
+          " * `true` if the installation was correctly initiated (i.e. the repo and spoon name were correct), `false` otherwise."
+        ],
+        "signature": "SpoonInstall:asyncInstallSpoonFromRepo(name, repo, callback)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:asyncInstallSpoonFromZipURL(url, callback)",
+        "desc": "Asynchronously download a Spoon zip file and install it.",
+        "doc": "Asynchronously download a Spoon zip file and install it.\n\nParameters:\n * url - URL of the zip file to install.\n * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:\n   * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file\n   * success - boolean indicating whether the installation was successful\n\nReturns:\n * `true` if the installation was correctly initiated (i.e. the URL is valid), `false` otherwise",
+        "name": "asyncInstallSpoonFromZipURL",
+        "parameters": [
+          " * url - URL of the zip file to install.",
+          " * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:",
+          "   * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file",
+          "   * success - boolean indicating whether the installation was successful"
+        ],
+        "returns": [
+          " * `true` if the installation was correctly initiated (i.e. the URL is valid), `false` otherwise"
+        ],
+        "signature": "SpoonInstall:asyncInstallSpoonFromZipURL(url, callback)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:asyncUpdateAllRepos()",
+        "desc": "Asynchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`",
+        "doc": "Asynchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.",
+        "name": "asyncUpdateAllRepos",
+        "notes": [
+          " * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions."
+        ],
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * None"
+        ],
+        "signature": "SpoonInstall:asyncUpdateAllRepos()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:asyncUpdateRepo(repo, callback)",
+        "desc": "Asynchronously fetch the information about the contents of a Spoon repository",
+        "doc": "Asynchronously fetch the information about the contents of a Spoon repository\n\nParameters:\n * repo - name of the repository to update. Defaults to `\"default\"`.\n * callback - if given, a function to be called after the update finishes (also if it fails). The function will receive the following arguments:\n   * repo - name of the repository\n   * success - boolean indicating whether the update succeeded\n\nReturns:\n * `true` if the update was correctly initiated (i.e. the repo name is valid), `nil` otherwise\n\nNotes:\n * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.",
+        "name": "asyncUpdateRepo",
+        "notes": [
+          " * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions."
+        ],
+        "parameters": [
+          " * repo - name of the repository to update. Defaults to `\"default\"`.",
+          " * callback - if given, a function to be called after the update finishes (also if it fails). The function will receive the following arguments:",
+          "   * repo - name of the repository",
+          "   * success - boolean indicating whether the update succeeded"
+        ],
+        "returns": [
+          " * `true` if the update was correctly initiated (i.e. the repo name is valid), `nil` otherwise"
+        ],
+        "signature": "SpoonInstall:asyncUpdateRepo(repo, callback)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:installSpoonFromRepo(name, repo)",
+        "desc": "Synchronously install a Spoon from a registered repository",
+        "doc": "Synchronously install a Spoon from a registered repository\n\nParameters:\n * name = Name of the Spoon to install.\n * repo - Name of the repository to use. Defaults to `\"default\"`\n\nReturns:\n * `true` if the installation was successful, `nil` otherwise.",
+        "name": "installSpoonFromRepo",
+        "parameters": [
+          " * name = Name of the Spoon to install.",
+          " * repo - Name of the repository to use. Defaults to `\"default\"`"
+        ],
+        "returns": [
+          " * `true` if the installation was successful, `nil` otherwise."
+        ],
+        "signature": "SpoonInstall:installSpoonFromRepo(name, repo)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:installSpoonFromZipURL(url)",
+        "desc": "Synchronously download a Spoon zip file and install it.",
+        "doc": "Synchronously download a Spoon zip file and install it.\n\nParameters:\n * url - URL of the zip file to install.\n\nReturns:\n * `true` if the installation was successful, `nil` otherwise",
+        "name": "installSpoonFromZipURL",
+        "parameters": [
+          " * url - URL of the zip file to install."
+        ],
+        "returns": [
+          " * `true` if the installation was successful, `nil` otherwise"
+        ],
+        "signature": "SpoonInstall:installSpoonFromZipURL(url)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:repolist()",
+        "desc": "Return a sorted list of registered Spoon repositories",
+        "doc": "Return a sorted list of registered Spoon repositories\n\nParameters:\n * None\n\nReturns:\n * Table containing a list of strings with the repository identifiers",
+        "name": "repolist",
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * Table containing a list of strings with the repository identifiers"
+        ],
+        "signature": "SpoonInstall:repolist()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:search(pat)",
+        "desc": "Search repositories for a pattern",
+        "doc": "Search repositories for a pattern\n\nParameters:\n * pat - Lua pattern that will be matched against the name and description of each spoon in the registered repositories. All text is converted to lowercase before searching it, so you can use all-lowercase in your pattern.\n\nReturns:\n * Table containing a list of matching entries. Each entry is a table with the following keys:\n   * name - Spoon name\n   * desc - description of the spoon\n   * repo - identifier in the repository where the match was found",
+        "name": "search",
+        "parameters": [
+          " * pat - Lua pattern that will be matched against the name and description of each spoon in the registered repositories. All text is converted to lowercase before searching it, so you can use all-lowercase in your pattern."
+        ],
+        "returns": [
+          " * Table containing a list of matching entries. Each entry is a table with the following keys:",
+          "   * name - Spoon name",
+          "   * desc - description of the spoon",
+          "   * repo - identifier in the repository where the match was found"
+        ],
+        "signature": "SpoonInstall:search(pat)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:updateAllRepos()",
+        "desc": "Synchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`",
+        "doc": "Synchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This is a synchronous call, which means Hammerspoon will be blocked until it finishes.\n * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.",
+        "name": "updateAllRepos",
+        "notes": [
+          " * This is a synchronous call, which means Hammerspoon will be blocked until it finishes.",
+          " * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions."
+        ],
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * None"
+        ],
+        "signature": "SpoonInstall:updateAllRepos()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:updateRepo(repo)",
+        "desc": "Synchronously fetch the information about the contents of a Spoon repository",
+        "doc": "Synchronously fetch the information about the contents of a Spoon repository\n\nParameters:\n * repo - name of the repository to update. Defaults to `\"default\"`.\n\nReturns:\n * `true` if the update was successful, `nil` otherwise\n\nNotes:\n * This is a synchronous call, which means Hammerspoon will be blocked until it finishes. For use in your configuration files, it's advisable to use `SpoonInstall.asyncUpdateRepo()` instead.\n * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.",
+        "name": "updateRepo",
+        "notes": [
+          " * This is a synchronous call, which means Hammerspoon will be blocked until it finishes. For use in your configuration files, it's advisable to use `SpoonInstall.asyncUpdateRepo()` instead.",
+          " * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions."
+        ],
+        "parameters": [
+          " * repo - name of the repository to update. Defaults to `\"default\"`."
+        ],
+        "returns": [
+          " * `true` if the update was successful, `nil` otherwise"
+        ],
+        "signature": "SpoonInstall:updateRepo(repo)",
+        "stripped_doc": "",
+        "type": "Method"
+      }
+    ],
+    "Variable": [
+      {
+        "def": "SpoonInstall.logger",
+        "desc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "doc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "name": "logger",
+        "signature": "SpoonInstall.logger",
+        "stripped_doc": "",
+        "type": "Variable"
+      },
+      {
+        "def": "SpoonInstall.repos",
+        "desc": "Table containing the list of available Spoon repositories. The key",
+        "doc": "Table containing the list of available Spoon repositories. The key\nof each entry is an identifier for the repository, and its value\nis a table with the following entries:\n * desc - Human-readable description for the repository\n * branch - Active git branch for the Spoon files\n * url - Base URL for the repository. For now the repository is assumed to be hosted in GitHub, and the URL should be the main base URL of the repository. Repository metadata needs to be stored under `docs/docs.json`, and the Spoon zip files need to be stored under `Spoons/`.\n\nDefault value:\n```\n{\n   default = {\n      url = \"https://github.com/Hammerspoon/Spoons\",\n      desc = \"Main Hammerspoon Spoon repository\",\n      branch = \"master\",\n   }\n}\n```",
+        "name": "repos",
+        "signature": "SpoonInstall.repos",
+        "stripped_doc": "of each entry is an identifier for the repository, and its value\nis a table with the following entries:\n * desc - Human-readable description for the repository\n * branch - Active git branch for the Spoon files\n * url - Base URL for the repository. For now the repository is assumed to be hosted in GitHub, and the URL should be the main base URL of the repository. Repository metadata needs to be stored under `docs/docs.json`, and the Spoon zip files need to be stored under `Spoons/`.\nDefault value:\n```\n{\n   default = {\n      url = \"https://github.com/Hammerspoon/Spoons\",\n      desc = \"Main Hammerspoon Spoon repository\",\n      branch = \"master\",\n   }\n}\n```",
+        "type": "Variable"
+      },
+      {
+        "def": "SpoonInstall.use_syncinstall",
+        "desc": "If `true`, `andUse()` will update repos and install packages synchronously. Defaults to `false`.",
+        "doc": "If `true`, `andUse()` will update repos and install packages synchronously. Defaults to `false`.\n\nKeep in mind that if you set this to `true`, Hammerspoon will\nblock until all missing Spoons are installed, but the notifications\nwill happen at a more \"human readable\" rate.",
+        "name": "use_syncinstall",
+        "signature": "SpoonInstall.use_syncinstall",
+        "stripped_doc": "Keep in mind that if you set this to `true`, Hammerspoon will\nblock until all missing Spoons are installed, but the notifications\nwill happen at a more \"human readable\" rate.",
+        "type": "Variable"
+      }
+    ],
+    "desc": "Install and manage Spoons and Spoon repositories",
+    "doc": "Install and manage Spoons and Spoon repositories\n\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/SpoonInstall.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/SpoonInstall.spoon.zip)",
+    "items": [
+      {
+        "def": "SpoonInstall:andUse(name, arg)",
+        "desc": "Declaratively install, load and configure a Spoon",
+        "doc": "Declaratively install, load and configure a Spoon\n\nParameters:\n * name - the name of the Spoon to install (without the `.spoon` extension). If the Spoon is already installed, it will be loaded using `hs.loadSpoon()`. If it is not installed, it will be installed using `SpoonInstall:asyncInstallSpoonFromRepo()` and then loaded.\n * arg - if provided, can be used to specify the configuration of the Spoon. The following keys are recognized (all are optional):\n   * repo - repository from where the Spoon should be installed if not present in the system, as defined in `SpoonInstall.repos`. Defaults to `\"default\"`.\n   * config - a table containing variables to be stored in the Spoon object to configure it. For example, `config = { answer = 42 }` will result in `spoon.<LoadedSpoon>.answer` being set to 42.\n   * hotkeys - a table containing hotkey bindings. If provided, will be passed as-is to the Spoon's `bindHotkeys()` method. The special string `\"default\"` can be given to use the Spoons `defaultHotkeys` variable, if it exists.\n   * fn - a function which will be called with the freshly-loaded Spoon object as its first argument.\n   * loglevel - if the Spoon has a variable called `logger`, its `setLogLevel()` method will be called with this value.\n   * start - if `true`, call the Spoon's `start()` method after configuring everything else.\n   * disable - if `true`, do nothing. Easier than commenting it out when you want to temporarily disable a spoon.\n\nReturns:\n * None",
+        "name": "andUse",
+        "parameters": [
+          " * name - the name of the Spoon to install (without the `.spoon` extension). If the Spoon is already installed, it will be loaded using `hs.loadSpoon()`. If it is not installed, it will be installed using `SpoonInstall:asyncInstallSpoonFromRepo()` and then loaded.",
+          " * arg - if provided, can be used to specify the configuration of the Spoon. The following keys are recognized (all are optional):",
+          "   * repo - repository from where the Spoon should be installed if not present in the system, as defined in `SpoonInstall.repos`. Defaults to `\"default\"`.",
+          "   * config - a table containing variables to be stored in the Spoon object to configure it. For example, `config = { answer = 42 }` will result in `spoon.<LoadedSpoon>.answer` being set to 42.",
+          "   * hotkeys - a table containing hotkey bindings. If provided, will be passed as-is to the Spoon's `bindHotkeys()` method. The special string `\"default\"` can be given to use the Spoons `defaultHotkeys` variable, if it exists.",
+          "   * fn - a function which will be called with the freshly-loaded Spoon object as its first argument.",
+          "   * loglevel - if the Spoon has a variable called `logger`, its `setLogLevel()` method will be called with this value.",
+          "   * start - if `true`, call the Spoon's `start()` method after configuring everything else.",
+          "   * disable - if `true`, do nothing. Easier than commenting it out when you want to temporarily disable a spoon."
+        ],
+        "returns": [
+          " * None"
+        ],
+        "signature": "SpoonInstall:andUse(name, arg)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:asyncInstallSpoonFromRepo(name, repo, callback)",
+        "desc": "Asynchronously install a Spoon from a registered repository",
+        "doc": "Asynchronously install a Spoon from a registered repository\n\nParameters:\n * name - Name of the Spoon to install.\n * repo - Name of the repository to use. Defaults to `\"default\"`\n * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:\n   * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file\n   * success - boolean indicating whether the installation was successful\n\nReturns:\n * `true` if the installation was correctly initiated (i.e. the repo and spoon name were correct), `false` otherwise.",
+        "name": "asyncInstallSpoonFromRepo",
+        "parameters": [
+          " * name - Name of the Spoon to install.",
+          " * repo - Name of the repository to use. Defaults to `\"default\"`",
+          " * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:",
+          "   * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file",
+          "   * success - boolean indicating whether the installation was successful"
+        ],
+        "returns": [
+          " * `true` if the installation was correctly initiated (i.e. the repo and spoon name were correct), `false` otherwise."
+        ],
+        "signature": "SpoonInstall:asyncInstallSpoonFromRepo(name, repo, callback)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:asyncInstallSpoonFromZipURL(url, callback)",
+        "desc": "Asynchronously download a Spoon zip file and install it.",
+        "doc": "Asynchronously download a Spoon zip file and install it.\n\nParameters:\n * url - URL of the zip file to install.\n * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:\n   * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file\n   * success - boolean indicating whether the installation was successful\n\nReturns:\n * `true` if the installation was correctly initiated (i.e. the URL is valid), `false` otherwise",
+        "name": "asyncInstallSpoonFromZipURL",
+        "parameters": [
+          " * url - URL of the zip file to install.",
+          " * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:",
+          "   * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file",
+          "   * success - boolean indicating whether the installation was successful"
+        ],
+        "returns": [
+          " * `true` if the installation was correctly initiated (i.e. the URL is valid), `false` otherwise"
+        ],
+        "signature": "SpoonInstall:asyncInstallSpoonFromZipURL(url, callback)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:asyncUpdateAllRepos()",
+        "desc": "Asynchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`",
+        "doc": "Asynchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.",
+        "name": "asyncUpdateAllRepos",
+        "notes": [
+          " * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions."
+        ],
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * None"
+        ],
+        "signature": "SpoonInstall:asyncUpdateAllRepos()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:asyncUpdateRepo(repo, callback)",
+        "desc": "Asynchronously fetch the information about the contents of a Spoon repository",
+        "doc": "Asynchronously fetch the information about the contents of a Spoon repository\n\nParameters:\n * repo - name of the repository to update. Defaults to `\"default\"`.\n * callback - if given, a function to be called after the update finishes (also if it fails). The function will receive the following arguments:\n   * repo - name of the repository\n   * success - boolean indicating whether the update succeeded\n\nReturns:\n * `true` if the update was correctly initiated (i.e. the repo name is valid), `nil` otherwise\n\nNotes:\n * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.",
+        "name": "asyncUpdateRepo",
+        "notes": [
+          " * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions."
+        ],
+        "parameters": [
+          " * repo - name of the repository to update. Defaults to `\"default\"`.",
+          " * callback - if given, a function to be called after the update finishes (also if it fails). The function will receive the following arguments:",
+          "   * repo - name of the repository",
+          "   * success - boolean indicating whether the update succeeded"
+        ],
+        "returns": [
+          " * `true` if the update was correctly initiated (i.e. the repo name is valid), `nil` otherwise"
+        ],
+        "signature": "SpoonInstall:asyncUpdateRepo(repo, callback)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:installSpoonFromRepo(name, repo)",
+        "desc": "Synchronously install a Spoon from a registered repository",
+        "doc": "Synchronously install a Spoon from a registered repository\n\nParameters:\n * name = Name of the Spoon to install.\n * repo - Name of the repository to use. Defaults to `\"default\"`\n\nReturns:\n * `true` if the installation was successful, `nil` otherwise.",
+        "name": "installSpoonFromRepo",
+        "parameters": [
+          " * name = Name of the Spoon to install.",
+          " * repo - Name of the repository to use. Defaults to `\"default\"`"
+        ],
+        "returns": [
+          " * `true` if the installation was successful, `nil` otherwise."
+        ],
+        "signature": "SpoonInstall:installSpoonFromRepo(name, repo)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:installSpoonFromZipURL(url)",
+        "desc": "Synchronously download a Spoon zip file and install it.",
+        "doc": "Synchronously download a Spoon zip file and install it.\n\nParameters:\n * url - URL of the zip file to install.\n\nReturns:\n * `true` if the installation was successful, `nil` otherwise",
+        "name": "installSpoonFromZipURL",
+        "parameters": [
+          " * url - URL of the zip file to install."
+        ],
+        "returns": [
+          " * `true` if the installation was successful, `nil` otherwise"
+        ],
+        "signature": "SpoonInstall:installSpoonFromZipURL(url)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall.logger",
+        "desc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "doc": "Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.",
+        "name": "logger",
+        "signature": "SpoonInstall.logger",
+        "stripped_doc": "",
+        "type": "Variable"
+      },
+      {
+        "def": "SpoonInstall:repolist()",
+        "desc": "Return a sorted list of registered Spoon repositories",
+        "doc": "Return a sorted list of registered Spoon repositories\n\nParameters:\n * None\n\nReturns:\n * Table containing a list of strings with the repository identifiers",
+        "name": "repolist",
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * Table containing a list of strings with the repository identifiers"
+        ],
+        "signature": "SpoonInstall:repolist()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall.repos",
+        "desc": "Table containing the list of available Spoon repositories. The key",
+        "doc": "Table containing the list of available Spoon repositories. The key\nof each entry is an identifier for the repository, and its value\nis a table with the following entries:\n * desc - Human-readable description for the repository\n * branch - Active git branch for the Spoon files\n * url - Base URL for the repository. For now the repository is assumed to be hosted in GitHub, and the URL should be the main base URL of the repository. Repository metadata needs to be stored under `docs/docs.json`, and the Spoon zip files need to be stored under `Spoons/`.\n\nDefault value:\n```\n{\n   default = {\n      url = \"https://github.com/Hammerspoon/Spoons\",\n      desc = \"Main Hammerspoon Spoon repository\",\n      branch = \"master\",\n   }\n}\n```",
+        "name": "repos",
+        "signature": "SpoonInstall.repos",
+        "stripped_doc": "of each entry is an identifier for the repository, and its value\nis a table with the following entries:\n * desc - Human-readable description for the repository\n * branch - Active git branch for the Spoon files\n * url - Base URL for the repository. For now the repository is assumed to be hosted in GitHub, and the URL should be the main base URL of the repository. Repository metadata needs to be stored under `docs/docs.json`, and the Spoon zip files need to be stored under `Spoons/`.\nDefault value:\n```\n{\n   default = {\n      url = \"https://github.com/Hammerspoon/Spoons\",\n      desc = \"Main Hammerspoon Spoon repository\",\n      branch = \"master\",\n   }\n}\n```",
+        "type": "Variable"
+      },
+      {
+        "def": "SpoonInstall:search(pat)",
+        "desc": "Search repositories for a pattern",
+        "doc": "Search repositories for a pattern\n\nParameters:\n * pat - Lua pattern that will be matched against the name and description of each spoon in the registered repositories. All text is converted to lowercase before searching it, so you can use all-lowercase in your pattern.\n\nReturns:\n * Table containing a list of matching entries. Each entry is a table with the following keys:\n   * name - Spoon name\n   * desc - description of the spoon\n   * repo - identifier in the repository where the match was found",
+        "name": "search",
+        "parameters": [
+          " * pat - Lua pattern that will be matched against the name and description of each spoon in the registered repositories. All text is converted to lowercase before searching it, so you can use all-lowercase in your pattern."
+        ],
+        "returns": [
+          " * Table containing a list of matching entries. Each entry is a table with the following keys:",
+          "   * name - Spoon name",
+          "   * desc - description of the spoon",
+          "   * repo - identifier in the repository where the match was found"
+        ],
+        "signature": "SpoonInstall:search(pat)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:updateAllRepos()",
+        "desc": "Synchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`",
+        "doc": "Synchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`\n\nParameters:\n * None\n\nReturns:\n * None\n\nNotes:\n * This is a synchronous call, which means Hammerspoon will be blocked until it finishes.\n * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.",
+        "name": "updateAllRepos",
+        "notes": [
+          " * This is a synchronous call, which means Hammerspoon will be blocked until it finishes.",
+          " * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions."
+        ],
+        "parameters": [
+          " * None"
+        ],
+        "returns": [
+          " * None"
+        ],
+        "signature": "SpoonInstall:updateAllRepos()",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall:updateRepo(repo)",
+        "desc": "Synchronously fetch the information about the contents of a Spoon repository",
+        "doc": "Synchronously fetch the information about the contents of a Spoon repository\n\nParameters:\n * repo - name of the repository to update. Defaults to `\"default\"`.\n\nReturns:\n * `true` if the update was successful, `nil` otherwise\n\nNotes:\n * This is a synchronous call, which means Hammerspoon will be blocked until it finishes. For use in your configuration files, it's advisable to use `SpoonInstall.asyncUpdateRepo()` instead.\n * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.",
+        "name": "updateRepo",
+        "notes": [
+          " * This is a synchronous call, which means Hammerspoon will be blocked until it finishes. For use in your configuration files, it's advisable to use `SpoonInstall.asyncUpdateRepo()` instead.",
+          " * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions."
+        ],
+        "parameters": [
+          " * repo - name of the repository to update. Defaults to `\"default\"`."
+        ],
+        "returns": [
+          " * `true` if the update was successful, `nil` otherwise"
+        ],
+        "signature": "SpoonInstall:updateRepo(repo)",
+        "stripped_doc": "",
+        "type": "Method"
+      },
+      {
+        "def": "SpoonInstall.use_syncinstall",
+        "desc": "If `true`, `andUse()` will update repos and install packages synchronously. Defaults to `false`.",
+        "doc": "If `true`, `andUse()` will update repos and install packages synchronously. Defaults to `false`.\n\nKeep in mind that if you set this to `true`, Hammerspoon will\nblock until all missing Spoons are installed, but the notifications\nwill happen at a more \"human readable\" rate.",
+        "name": "use_syncinstall",
+        "signature": "SpoonInstall.use_syncinstall",
+        "stripped_doc": "Keep in mind that if you set this to `true`, Hammerspoon will\nblock until all missing Spoons are installed, but the notifications\nwill happen at a more \"human readable\" rate.",
+        "type": "Variable"
+      }
+    ],
+    "name": "SpoonInstall",
+    "stripped_doc": "\nDownload: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/SpoonInstall.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/SpoonInstall.spoon.zip)",
+    "submodules": [],
+    "type": "Module"
+  }
+]

--- a/roles/hammerspoon/.hammerspoon/Spoons/SpoonInstall.spoon/init.lua
+++ b/roles/hammerspoon/.hammerspoon/Spoons/SpoonInstall.spoon/init.lua
@@ -1,0 +1,447 @@
+--- === SpoonInstall ===
+---
+--- Install and manage Spoons and Spoon repositories
+---
+--- Download: [https://github.com/Hammerspoon/Spoons/raw/master/Spoons/SpoonInstall.spoon.zip](https://github.com/Hammerspoon/Spoons/raw/master/Spoons/SpoonInstall.spoon.zip)
+
+local obj={}
+obj.__index = obj
+
+-- Metadata
+obj.name = "SpoonInstall"
+obj.version = "0.1"
+obj.author = "Diego Zamboni <diego@zzamboni.org>"
+obj.homepage = "https://github.com/Hammerspoon/Spoons"
+obj.license = "MIT - https://opensource.org/licenses/MIT"
+
+--- SpoonInstall.logger
+--- Variable
+--- Logger object used within the Spoon. Can be accessed to set the default log level for the messages coming from the Spoon.
+obj.logger = hs.logger.new('SpoonInstall')
+
+--- SpoonInstall.repos
+--- Variable
+--- Table containing the list of available Spoon repositories. The key
+--- of each entry is an identifier for the repository, and its value
+--- is a table with the following entries:
+---  * desc - Human-readable description for the repository
+---  * branch - Active git branch for the Spoon files
+---  * url - Base URL for the repository. For now the repository is assumed to be hosted in GitHub, and the URL should be the main base URL of the repository. Repository metadata needs to be stored under `docs/docs.json`, and the Spoon zip files need to be stored under `Spoons/`.
+---
+--- Default value:
+--- ```
+--- {
+---    default = {
+---       url = "https://github.com/Hammerspoon/Spoons",
+---       desc = "Main Hammerspoon Spoon repository",
+---       branch = "master",
+---    }
+--- }
+--- ```
+obj.repos = {
+   default = {
+      url = "https://github.com/Hammerspoon/Spoons",
+      desc = "Main Hammerspoon Spoon repository",
+      branch = "master",
+   }
+}
+
+--- SpoonInstall.use_syncinstall
+--- Variable
+--- If `true`, `andUse()` will update repos and install packages synchronously. Defaults to `false`.
+---
+--- Keep in mind that if you set this to `true`, Hammerspoon will
+--- block until all missing Spoons are installed, but the notifications
+--- will happen at a more "human readable" rate.
+obj.use_syncinstall = false
+
+-- Execute a command and return its output with trailing EOLs trimmed. If the command fails, an error message is logged.
+local function _x(cmd, errfmt, ...)
+   local output, status = hs.execute(cmd)
+   if status then
+      local trimstr = string.gsub(output, "\n*$", "")
+      return trimstr
+   else
+      obj.logger.ef(errfmt, ...)
+      return nil
+   end
+end
+
+-- --------------------------------------------------------------------
+-- Spoon repository management
+
+-- Internal callback to process and store the data from docs.json about a repository
+-- callback is called with repo as arguments, only if the call is successful
+function obj:_storeRepoJSON(repo, callback, status, body, hdrs)
+   local success=nil
+   if (status < 100) or (status >= 400) then
+      self.logger.ef("Error fetching JSON data for repository '%s'. Error code %d: %s", repo, status, body or "<no error message>")
+   else
+      local json = hs.json.decode(body)
+      if json then
+         self.repos[repo].data = {}
+         for i,v in ipairs(json) do
+            v.download_url = self.repos[repo].download_base_url .. v.name .. ".spoon.zip"
+            self.repos[repo].data[v.name] = v
+         end
+         self.logger.df("Updated JSON data for repository '%s'", repo)
+         success=true
+      else
+         self.logger.ef("Invalid JSON received for repository '%s': %s", repo, body)
+      end
+   end
+   if callback then
+      callback(repo, success)
+   end
+   return success
+end
+
+-- Internal function to return the URL of the docs.json file based on the URL of a GitHub repo
+function obj:_build_repo_json_url(repo)
+   if self.repos[repo] and self.repos[repo].url then
+      local branch = self.repos[repo].branch or "master"
+      self.repos[repo].json_url = string.gsub(self.repos[repo].url, "/$", "") .. "/raw/"..branch.."/docs/docs.json"
+      self.repos[repo].download_base_url = string.gsub(self.repos[repo].url, "/$", "") .. "/raw/"..branch.."/Spoons/"
+      return true
+   else
+      self.logger.ef("Invalid or unknown repository '%s'", repo)
+      return nil
+   end
+end
+
+--- SpoonInstall:asyncUpdateRepo(repo, callback)
+--- Method
+--- Asynchronously fetch the information about the contents of a Spoon repository
+---
+--- Parameters:
+---  * repo - name of the repository to update. Defaults to `"default"`.
+---  * callback - if given, a function to be called after the update finishes (also if it fails). The function will receive the following arguments:
+---    * repo - name of the repository
+---    * success - boolean indicating whether the update succeeded
+---
+--- Returns:
+---  * `true` if the update was correctly initiated (i.e. the repo name is valid), `nil` otherwise
+---
+--- Notes:
+---  * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.
+function obj:asyncUpdateRepo(repo, callback)
+   if not repo then repo = 'default' end
+   if self:_build_repo_json_url(repo) then
+      hs.http.asyncGet(self.repos[repo].json_url, nil, hs.fnutils.partial(self._storeRepoJSON, self, repo, callback))
+      return true
+   else
+      return nil
+   end
+end
+
+--- SpoonInstall:updateRepo(repo)
+--- Method
+--- Synchronously fetch the information about the contents of a Spoon repository
+---
+--- Parameters:
+---  * repo - name of the repository to update. Defaults to `"default"`.
+---
+--- Returns:
+---  * `true` if the update was successful, `nil` otherwise
+---
+--- Notes:
+---  * This is a synchronous call, which means Hammerspoon will be blocked until it finishes. For use in your configuration files, it's advisable to use `SpoonInstall.asyncUpdateRepo()` instead.
+---  * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.
+function obj:updateRepo(repo)
+   if not repo then repo = 'default' end
+   if self:_build_repo_json_url(repo) then
+      local a,b,c = hs.http.get(self.repos[repo].json_url)
+      return self:_storeRepoJSON(repo, nil, a, b, c)
+   else
+      return nil
+   end
+end
+
+--- SpoonInstall:asyncUpdateAllRepos()
+--- Method
+--- Asynchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.
+function obj:asyncUpdateAllRepos()
+   for k,v in pairs(self.repos) do
+      self:asyncUpdateRepo(k)
+   end
+end
+
+--- SpoonInstall:updateAllRepos()
+--- Method
+--- Synchronously fetch the information about the contents of all Spoon repositories registered in `SpoonInstall.repos`
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * None
+---
+--- Notes:
+---  * This is a synchronous call, which means Hammerspoon will be blocked until it finishes.
+---  * For now, the repository data is not persisted, so you need to update it after every restart if you want to use any of the install functions.
+function obj:updateAllRepos()
+   for k,v in pairs(self.repos) do
+      self:updateRepo(k)
+   end
+end
+
+--- SpoonInstall:repolist()
+--- Method
+--- Return a sorted list of registered Spoon repositories
+---
+--- Parameters:
+---  * None
+---
+--- Returns:
+---  * Table containing a list of strings with the repository identifiers
+function obj:repolist()
+   local keys={}
+   -- Create sorted list of keys
+   for k,v in pairs(self.repos) do table.insert(keys, k) end
+   table.sort(keys)
+   return keys
+end
+
+--- SpoonInstall:search(pat)
+--- Method
+--- Search repositories for a pattern
+---
+--- Parameters:
+---  * pat - Lua pattern that will be matched against the name and description of each spoon in the registered repositories. All text is converted to lowercase before searching it, so you can use all-lowercase in your pattern.
+---
+--- Returns:
+---  * Table containing a list of matching entries. Each entry is a table with the following keys:
+---    * name - Spoon name
+---    * desc - description of the spoon
+---    * repo - identifier in the repository where the match was found
+function obj:search(pat)
+   local res={}
+   for repo,v in pairs(self.repos) do
+      if v.data then
+         for spoon,rec in pairs(v.data) do
+            if string.find(string.lower(rec.name .. "\n" .. rec.desc), pat) then
+               table.insert(res, { name = rec.name, desc = rec.desc, repo = repo })
+            end
+         end
+      else
+         self.logger.ef("Repository data for '%s' not available - call spoon.SpoonInstall:updateRepo('%s'), then try again.", repo, repo)
+      end
+   end
+   return res
+end
+
+-- --------------------------------------------------------------------
+-- Spoon installation
+
+-- Internal callback function to finalize the installation of a spoon after the zip file has been downloaded.
+-- callback, if given, is called with (urlparts, success) as arguments
+function obj:_installSpoonFromZipURLgetCallback(urlparts, callback, status, body, headers)
+   local success=nil
+   if (status < 100) or (status >= 400) then
+      self.logger.ef("Error downloading %s. Error code %d: %s", urlparts.absoluteString, status, body or "<none>")
+   else
+      -- Write the zip file to disk in a temporary directory
+      local tmpdir=_x("/usr/bin/mktemp -d", "Error creating temporary directory to download new spoon.")
+      if tmpdir then
+         local outfile = string.format("%s/%s", tmpdir, urlparts.lastPathComponent)
+         local f=assert(io.open(outfile, "w"))
+         f:write(body)
+         f:close()
+
+         -- Check its contents - only one *.spoon directory should be in there
+         output = _x(string.format("/usr/bin/unzip -l %s '*.spoon/' | /usr/bin/awk '$NF ~ /\\.spoon\\/$/ { print $NF }' | /usr/bin/wc -l", outfile),
+                     "Error examining downloaded zip file %s, leaving it in place for your examination.", outfile)
+         if output then
+            if (tonumber(output) or 0) == 1 then
+               -- Uncompress the zip file
+               local outdir = string.format("%s/Spoons", hs.configdir)
+               if _x(string.format("/usr/bin/unzip -o %s -d %s 2>&1", outfile, outdir),
+                     "Error uncompressing file %s, leaving it in place for your examination.", outfile) then
+                  -- And finally, install it using Hammerspoon itself
+                  self.logger.f("Downloaded and installed %s", urlparts.absoluteString)
+                  _x(string.format("/bin/rm -rf '%s'", tmpdir), "Error removing directory %s", tmpdir)
+                  success=true
+               end
+            else
+               self.logger.ef("The downloaded zip file %s is invalid - it should contain exactly one spoon. Leaving it in place for your examination.", outfile) 
+            end
+         end
+      end
+   end
+   if callback then
+      callback(urlparts, success)
+   end
+   return success
+end
+
+--- SpoonInstall:asyncInstallSpoonFromZipURL(url, callback)
+--- Method
+--- Asynchronously download a Spoon zip file and install it.
+---
+--- Parameters:
+---  * url - URL of the zip file to install.
+---  * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:
+---    * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file
+---    * success - boolean indicating whether the installation was successful
+---
+--- Returns:
+---  * `true` if the installation was correctly initiated (i.e. the URL is valid), `false` otherwise
+function obj:asyncInstallSpoonFromZipURL(url, callback)
+   local urlparts = hs.http.urlParts(url)
+   local dlfile = urlparts.lastPathComponent
+   if dlfile and dlfile ~= "" and urlparts.pathExtension == "zip" then
+      hs.http.asyncGet(url, nil, hs.fnutils.partial(self._installSpoonFromZipURLgetCallback, self, urlparts, callback))
+      return true
+   else
+      self.logger.ef("Invalid URL %s, must point to a zip file", url)
+      return nil
+   end
+end
+
+--- SpoonInstall:installSpoonFromZipURL(url)
+--- Method
+--- Synchronously download a Spoon zip file and install it.
+---
+--- Parameters:
+---  * url - URL of the zip file to install.
+---
+--- Returns:
+---  * `true` if the installation was successful, `nil` otherwise
+function obj:installSpoonFromZipURL(url)
+   local urlparts = hs.http.urlParts(url)
+   local dlfile = urlparts.lastPathComponent
+   if dlfile and dlfile ~= "" and urlparts.pathExtension == "zip" then
+      a,b,c=hs.http.get(url)
+      return self:_installSpoonFromZipURLgetCallback(urlparts, nil, a, b, c)
+   else
+      self.logger.ef("Invalid URL %s, must point to a zip file", url)
+      return nil
+   end
+end
+
+-- Internal function to check if a Spoon/Repo combination is valid
+function obj:_is_valid_spoon(name, repo)
+   if self.repos[repo] then
+      if self.repos[repo].data then
+         if self.repos[repo].data[name] then
+            return true
+         else
+            self.logger.ef("Spoon '%s' does not exist in repository '%s'. Please check and try again.", name, repo)
+         end
+      else
+         self.logger.ef("Repository data for '%s' not available - call spoon.SpoonInstall:updateRepo('%s'), then try again.", repo, repo)
+      end
+   else
+      self.logger.ef("Invalid or unknown repository '%s'", repo)
+   end
+   return nil
+end
+
+--- SpoonInstall:asyncInstallSpoonFromRepo(name, repo, callback)
+--- Method
+--- Asynchronously install a Spoon from a registered repository
+---
+--- Parameters:
+---  * name - Name of the Spoon to install.
+---  * repo - Name of the repository to use. Defaults to `"default"`
+---  * callback - if given, a function to call after the installation finishes (also if it fails). The function receives the following arguments:
+---    * urlparts - Result of calling `hs.http.urlParts` on the URL of the Spoon zip file
+---    * success - boolean indicating whether the installation was successful
+---
+--- Returns:
+---  * `true` if the installation was correctly initiated (i.e. the repo and spoon name were correct), `false` otherwise.
+function obj:asyncInstallSpoonFromRepo(name, repo, callback)
+   if not repo then repo = 'default' end
+   if self:_is_valid_spoon(name, repo) then
+      self:asyncInstallSpoonFromZipURL(self.repos[repo].data[name].download_url, callback)
+   end
+   return nil
+end
+
+--- SpoonInstall:installSpoonFromRepo(name, repo)
+--- Method
+--- Synchronously install a Spoon from a registered repository
+---
+--- Parameters:
+---  * name = Name of the Spoon to install.
+---  * repo - Name of the repository to use. Defaults to `"default"`
+---
+--- Returns:
+---  * `true` if the installation was successful, `nil` otherwise.
+function obj:installSpoonFromRepo(name, repo, callback)
+   if not repo then repo = 'default' end
+   if self:_is_valid_spoon(name, repo) then
+      return self:installSpoonFromZipURL(self.repos[repo].data[name].download_url)
+   end
+   return nil
+end
+
+--- SpoonInstall:andUse(name, arg)
+--- Method
+--- Declaratively install, load and configure a Spoon
+---
+--- Parameters:
+---  * name - the name of the Spoon to install (without the `.spoon` extension). If the Spoon is already installed, it will be loaded using `hs.loadSpoon()`. If it is not installed, it will be installed using `SpoonInstall:asyncInstallSpoonFromRepo()` and then loaded.
+---  * arg - if provided, can be used to specify the configuration of the Spoon. The following keys are recognized (all are optional):
+---    * repo - repository from where the Spoon should be installed if not present in the system, as defined in `SpoonInstall.repos`. Defaults to `"default"`.
+---    * config - a table containing variables to be stored in the Spoon object to configure it. For example, `config = { answer = 42 }` will result in `spoon.<LoadedSpoon>.answer` being set to 42.
+---    * hotkeys - a table containing hotkey bindings. If provided, will be passed as-is to the Spoon's `bindHotkeys()` method. The special string `"default"` can be given to use the Spoons `defaultHotkeys` variable, if it exists.
+---    * fn - a function which will be called with the freshly-loaded Spoon object as its first argument.
+---    * loglevel - if the Spoon has a variable called `logger`, its `setLogLevel()` method will be called with this value.
+---    * start - if `true`, call the Spoon's `start()` method after configuring everything else.
+---    * disable - if `true`, do nothing. Easier than commenting it out when you want to temporarily disable a spoon.
+---
+--- Returns:
+---  * None
+function obj:andUse(name, arg)
+   if not arg then arg = {} end
+   if arg.disable then return true end
+   if hs.spoons.use(name, arg, true) then
+      return true
+   else
+      local repo = arg.repo or "default"
+      if self.repos[repo] then
+         if self.repos[repo].data then
+            local load_and_config = function(_, success)
+               if success then
+                  hs.notify.show("Spoon installed by SpoonInstall", name .. ".spoon is now available", "")
+                  hs.spoons.use(name, arg)
+               else
+                  obj.logger.ef("Error installing Spoon '%s' from repo '%s'", name, repo)
+               end
+            end
+            if self.use_syncinstall then
+               return load_and_config(nil, self:installSpoonFromRepo(name, repo))
+            else
+               self:asyncInstallSpoonFromRepo(name, repo, load_and_config)
+            end
+         else
+            local update_repo_and_continue = function(_, success)
+               if success then
+                  obj:andUse(name, arg)
+               else
+                  obj.logger.ef("Error updating repository '%s'", repo)
+               end
+            end
+            if self.use_syncinstall then
+               return update_repo_and_continue(nil, self:updateRepo(repo))
+            else
+               self:asyncUpdateRepo(repo, update_repo_and_continue)
+            end
+         end
+      else
+         obj.logger.ef("Unknown repository '%s' for Spoon", repo, name)
+      end
+   end
+end
+
+return obj

--- a/roles/hammerspoon/.hammerspoon/config/caffeine.lua
+++ b/roles/hammerspoon/.hammerspoon/config/caffeine.lua
@@ -1,7 +1,15 @@
 -- Caffeine（スリープ防止）: 起動時にオン・hyper+F6 でトグル
+-- SpoonInstall 経由で宣言的に導入する（未インストールなら公式リポジトリから自動取得）。
+-- 順序は従来どおり bindHotkeys → start() → clicked()。andUse の start=true は使わず
+-- fn 内で start→clicked を呼ぶことで、clicked を start の後に確実に実行する。
 
--- Load Spoons: https://github.com/Hammerspoon/Spoons
-hs.loadSpoon("Caffeine")
-spoon.Caffeine:bindHotkeys({toggle={hyper, "f6"}})
-spoon.Caffeine:start()
-spoon.Caffeine:clicked()
+hs.loadSpoon("SpoonInstall")
+local Install = spoon.SpoonInstall
+
+Install:andUse("Caffeine", {
+  hotkeys = { toggle = {hyper, "f6"} },
+  fn = function(s)
+    s:start()
+    s:clicked()
+  end,
+})

--- a/roles/hammerspoon/install.sh
+++ b/roles/hammerspoon/install.sh
@@ -10,13 +10,9 @@ brew list --cask hammerspoon > /dev/null 2>&1 || {
 
 (
 cd ${CURRENT_PATH}
+# .hammerspoon（config/ と Spoons/SpoonInstall.spoon を含む）を配布する。
+# 他の Spoon（Caffeine 等）は init.lua の SpoonInstall:andUse が実行時に取得する。
 cp -fr .hammerspoon ${HOME}
-
-# Spoons
-mkdir -p ${HOME}/.hammerspoon/Spoons
-
-## Caffeine
-curl -sL https://github.com/Hammerspoon/Spoons/raw/master/Spoons/Caffeine.spoon.zip -# | /usr/bin/tar xz -C ~/.hammerspoon/Spoons/
 )
 
 defaults write -app Terminal AppleLanguages "(en, ja)"


### PR DESCRIPTION
## 概要
独自の `curl` 取得＋手動 `loadSpoon` を、de-facto 標準の **SpoonInstall** による宣言的管理へ寄せる（相談・調査の結論どおり）。install も設定も config 側へ集約し、Spoon を増やすのは `andUse` 1行で済むようにする。

## 変更
- **`Spoons/SpoonInstall.spoon` を vendor**（作者 Diego Zamboni・MIT／公式 `Hammerspoon/Spoons` から取得）＋ **`Spoons/.gitignore`** で SpoonInstall 以外は追跡しない（他 Spoon は実行時に SpoonInstall が公式リポジトリから取得）。
- **`config/caffeine.lua`**: `SpoonInstall:andUse("Caffeine", {...})` へ書き換え。**順序は従来どおり bindHotkeys → start → clicked** を厳密に保持（`start=true` は使わず `fn` 内で `start()`→`clicked()`）。
- **`install.sh`**: `Spoons` の `mkdir` と Caffeine の `curl` を廃止。`cp -fr .hammerspoon` が vendored SpoonInstall を配布し、Caffeine は `andUse` が取得する。

## 裏取り
- `andUse` のオプション（`hotkeys`/`fn`/`start` 等）は vendored 本体のドキュメントで確認（一次ソース）。`fn` はロード済み Spoon オブジェクトを引数に受ける。
- `.gitignore` の効きを検証: `SpoonInstall.spoon` は追跡可、`Caffeine.spoon`（実行時取得分）は ignore。
- `hyper`（`toggle={hyper,"f6"}`）は既存コードでも未定義（nil）＝そのまま保持。掃除は別 PR。

## マージ後
- ライブ反映は `make install ROLE=hammerspoon`。既に Caffeine.spoon がある環境では andUse が即ロード、無い環境では公式リポジトリから取得。

🤖 Generated with [Claude Code](https://claude.com/claude-code)