### PR TITLE
feat: ロール個別の update フック make update ROLE=X を追加（ADR 0002）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ help:
 	@echo "make create ROLE=vim"
 	@echo "make install ROLE=vim"
 	@echo "make install"
+	@echo "make update ROLE=hammerspoon"
 	@echo "make list"
 
 
@@ -26,6 +27,11 @@ create: ## Create ROLE <ROLE=RoleName>
 .PHONY: install
 install: ## Install ROLEs [ROLE=RoleName]
 	@scripts/install.sh $(ROLE)
+
+
+.PHONY: update
+update: ## Update ROLEs (run roles/<role>/update.sh if present) [ROLE=RoleName]
+	@scripts/update.sh $(ROLE)
 
 
 .PHONY: list

--- a/docs/adr/0002-per-role-update-hook.md
+++ b/docs/adr/0002-per-role-update-hook.md
@@ -1,0 +1,21 @@
+# 0002. ロール個別の更新は make update ROLE=X（roles/X/update.sh フック）で行う
+
+- Status: Accepted
+- Date: 2026-08-05
+
+## Context
+- vendored した依存（例: Hammerspoon の `SpoonInstall.spoon`）は、上流に追従して時々更新したい。上流の公式 Spoons リポジトリは**スプーン個別のリリースタグを打たず** `master` に in-place 更新するため、「更新」は最新を取得して差分をコミットする**手動 bump** になる。
+- この「更新」はロール固有の処理。トップの `Makefile` / `scripts` に**ロール個別ロジックを持たせたくない**（全体管理の中に個別管理が混ざるのを避ける）。
+- 既存規約では `make install ROLE=X` が `scripts/install.sh` を通じて `roles/X/install.sh` を汎用ディスパッチで実行している。更新もこれと対称にしたい。
+
+## Decision
+- `make update ROLE=X` を新設する。`scripts/update.sh` が汎用ディスパッチャとして働き、`roles/X/update.sh` があれば実行、無ければ `[SKIP] X に update 手順はありません。` と表示して正常終了する（**update はロール任意**。install と違い未定義でもエラーにしない）。
+- `make update`（ROLE 無し）は `roles.lst` を回し、`update.sh` を持つロールだけ更新する。
+- ロール個別の更新ロジックは `roles/X/update.sh`（シェル）に**局所化**する。既存の `install.sh` 規約と対称にし、**ロールごとの Makefile は導入しない**（機構の二重化を避け、シェル一貫の規約を保つ）。必要なら `update.sh` 内で任意の処理（`make` 呼び出し含む）が書ける。
+- 最初の実装は `roles/hammerspoon/update.sh`＝vendored `SpoonInstall.spoon` を公式リポジトリの最新で上書きする。実行後の `git diff` が版の差分になり、レビューしてコミットすることが版 bump になる（＝差分が空なら最新、という check も兼ねる）。
+
+## Consequences
+- トップ（`Makefile` / `scripts`）は**純粋なディスパッチ**のままで、ロール個別知識を持たない。個別の更新はロール内に閉じる。
+- update を持たないロールは SKIP されるだけで、`make update`（全体）も安全に流せる。
+- role ごとの Makefile を使わないため、`install.sh`／`update.sh` というシェル一貫の規約が保たれる。
+- vendored 依存の版管理は「git がピン、update フックで最新取得、git diff をレビューしてコミット」という手動 bump 運用になる（上流に版番号フィードが無いため、これが現実解）。

--- a/roles/hammerspoon/update.sh
+++ b/roles/hammerspoon/update.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env zsh
+set -e
+
+# roles/hammerspoon の update フック（make update ROLE=hammerspoon から実行）。
+# vendored な SpoonInstall.spoon を公式 Spoons リポジトリの最新で上書きする。
+# 実行後、git diff が空なら最新、差分があれば更新あり（レビューしてコミット＝版 bump）。
+# 参照: docs/adr/0002-per-role-update-hook.md
+
+readonly CURRENT_PATH=$(cd $(dirname $0); pwd)
+readonly SPOONS_DIR="${CURRENT_PATH}/.hammerspoon/Spoons"
+readonly ZIP_URL="https://github.com/Hammerspoon/Spoons/raw/master/Spoons/SpoonInstall.spoon.zip"
+
+echo "[INFO] Refreshing vendored SpoonInstall.spoon from ${ZIP_URL}"
+curl -sL "${ZIP_URL}" | /usr/bin/tar xz -C "${SPOONS_DIR}"
+echo "[INFO] Done. 'git diff roles/hammerspoon/.hammerspoon/Spoons/SpoonInstall.spoon' が空なら最新、差分があれば更新（レビューしてコミット）。"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env zsh
+set -e
+
+readonly ROLE_ROOT_PATH=roles
+readonly UPDATE_SHELL=update.sh
+DOTF_ROLES_FILE=${DOTF_ROLES_FILE:-roles.lst}
+
+
+timestamp() {
+  date '+%Y-%m-%d %H:%M:%S'
+}
+
+# ロール個別の更新フック roles/<role>/update.sh を実行する。
+# install と違い update.sh は任意で、無いロールはエラーにせず SKIP する。
+_update() {
+  local role="${1:?[ERROR] role is required.}"
+  local role_path="${ROLE_ROOT_PATH}/${role}"
+  local updatesh_path="${role_path}/${UPDATE_SHELL}"
+
+  if [[ ! -d ${role_path} ]]; then
+    echo "[ERROR] ${role_path} is not found."
+    return 1
+  fi
+  if [[ ! -e ${updatesh_path} ]]; then
+    echo "[SKIP] ${role} に update 手順はありません。"
+    return 0
+  fi
+  zsh ${updatesh_path}
+}
+
+_individual() {
+  local role="${1:?[ERROR] ROLE is required.}"
+  local index="${2:-1/1}"
+  printf "$(timestamp) [INFO] %s Updating ${role}\n" "($index)"
+  _update ${role}
+}
+
+_all() {
+  [[ -f $DOTF_ROLES_FILE ]] || {
+    echo "[ERROR] $DOTF_ROLES_FILE is not found."
+    return 1
+  }
+
+  local role i
+  local roles=$(grep -v -e '^\s*#' -e '^\s*$' $DOTF_ROLES_FILE)
+  local all=$(echo $roles | wc -w | xargs)
+
+  for role in ${=roles}; do
+    _individual ${role} "$((++i))/$all"
+  done
+}
+
+main() {
+  if [ $# = 0 ]; then
+    _all
+  else
+    _individual $@
+  fi
+}
+
+main $@


### PR DESCRIPTION
## 概要
vendored 依存（例: Hammerspoon の `SpoonInstall.spoon`）の更新など、**ロール固有の「更新」**を、トップ（Makefile/scripts）に個別ロジックを持たせずに扱う汎用フックを追加する。`install` と対称のディスパッチ方式。設計判断は **ADR 0002** に記録。

## 変更
- **Makefile**: `update` ターゲット追加（`@scripts/update.sh $(ROLE)`）。help と例も更新。
- **scripts/update.sh**（新規・汎用ディスパッチャ）: `roles/<role>/update.sh` があれば実行、無ければ `[SKIP] <role> に update 手順はありません。` と表示して正常終了（**update はロール任意**。install と違い未定義でもエラーにしない）。ROLE 無しは `roles.lst` を回す。
- **roles/hammerspoon/update.sh**（新規）: vendored `SpoonInstall.spoon` を公式リポジトリの最新で上書き。実行後の `git diff` が版差分（空＝最新／差分＝更新→レビューしてコミット）。
- **docs/adr/0002-per-role-update-hook.md**（新規 ADR）: role ごとの Makefile ではなく、`install.sh` 規約と対称のシェルフックにする理由・結論。

## 動作確認
- `make update ROLE=hammerspoon` → vendored 更新・`git diff` 空＝最新（冪等）。
- `make update ROLE=git`（update.sh 無し）→ `[SKIP] git に update 手順はありません。`。
- `make update`（全 39 ロール）→ 38 SKIP・1 実行（hammerspoon）。
- `make help` に `update` ターゲットと例が表示。

## 位置づけ
- 前段の相談（SpoonInstall のバージョン UP をどう知り・どう反映するか）への回答＝「git ピン＋update フックで最新取得＋git diff をレビューしてコミット」という手動 bump 運用を、この機構で実現する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)