### PR TITLE
feat(hammerspoon): クリップボード履歴/翻訳/ショートカット一覧の Spoon を試用追加

### DIFF
--- a/roles/hammerspoon/.hammerspoon/config/clipboard.lua
+++ b/roles/hammerspoon/.hammerspoon/config/clipboard.lua
@@ -1,0 +1,18 @@
+-- クリップボード履歴（ClipboardTool・SpoonInstall 経由）。
+-- Maccy からの乗り換え候補として試用中（当面 Maccy と併用）。テキスト専用。
+-- 画像は対象外（必要なら macOS Spotlight のクリップボード履歴を別途 ON）。
+-- ※ ホットキー/設定は好みで調整可。
+
+hs.loadSpoon("SpoonInstall")
+spoon.SpoonInstall:andUse("ClipboardTool", {
+  config = {
+    hist_size = 200,          -- 履歴の保持数
+    paste_on_select = true,   -- 選択した項目を現アプリへ自動ペースト
+    show_in_menubar = true,   -- メニューバーアイコンを表示
+  },
+  hotkeys = {
+    -- ⌘⇧V で履歴チューザを開く（Maccy の既定 ⌘⇧C と衝突しないよう別キーにしている）
+    show_clipboard = {{"cmd", "shift"}, "v"},
+  },
+  start = true,
+})

--- a/roles/hammerspoon/.hammerspoon/config/keybindings.lua
+++ b/roles/hammerspoon/.hammerspoon/config/keybindings.lua
@@ -1,0 +1,10 @@
+-- 自分が Hammerspoon に登録したショートカット一覧を表示（HSKeybindings・SpoonInstall 経由）。
+-- HSKeybindings は bindHotkeys を持たないため、fn 内で show() を手動 bind する。
+-- ※ この spoon はライブ未検証。反映後に ⌘⇧K で表示を確認し、必要なら調整する。
+
+hs.loadSpoon("SpoonInstall")
+spoon.SpoonInstall:andUse("HSKeybindings", {
+  fn = function(s)
+    hs.hotkey.bind({"cmd", "shift"}, "k", function() s:show() end)   -- ⌘⇧K で一覧表示
+  end,
+})

--- a/roles/hammerspoon/.hammerspoon/config/translate.lua
+++ b/roles/hammerspoon/.hammerspoon/config/translate.lua
@@ -1,0 +1,12 @@
+-- 選択テキストの翻訳ポップアップ（PopupTranslateSelection・SpoonInstall 経由）。
+-- 言語コードは Google 翻訳準拠の 2 文字（en / ja など）。
+-- ※ ホットキーは好みで調整可。
+
+hs.loadSpoon("SpoonInstall")
+spoon.SpoonInstall:andUse("PopupTranslateSelection", {
+  hotkeys = {
+    translate       = {{"cmd", "ctrl"}, "t"},   -- ⌘⌃T: 言語自動検出で翻訳
+    translate_to_ja = {{"cmd", "ctrl"}, "j"},   -- ⌘⌃J: 日本語へ
+    translate_to_en = {{"cmd", "ctrl"}, "e"},   -- ⌘⌃E: 英語へ
+  },
+})

--- a/roles/hammerspoon/.hammerspoon/init.lua
+++ b/roles/hammerspoon/.hammerspoon/init.lua
@@ -8,3 +8,6 @@ require("config.behavior")     -- Preferences > Behavior
 require("config.app_toggle")   -- アプリ トグル（ホットキー）
 require("config.ime")          -- En/Ja 切替
 require("config.caffeine")     -- Caffeine（スリープ防止）
+require("config.clipboard")    -- クリップボード履歴（ClipboardTool・試用）
+require("config.translate")    -- 選択テキストの翻訳（PopupTranslateSelection）
+require("config.keybindings")  -- 自分のショートカット一覧（HSKeybindings・未検証のため最後）


### PR DESCRIPTION
## 概要
`SpoonInstall:andUse` で公式 Spoon を 3 つ `config/` に追加（実行時に公式リポジトリから自動取得）。**試用**の位置づけで、ホットキーは調整前提。

| ファイル | Spoon | 用途 | ホットキー |
|---|---|---|---|
| `config/clipboard.lua` | ClipboardTool | クリップボード履歴（テキスト） | ⌘⇧V で履歴 |
| `config/translate.lua` | PopupTranslateSelection | 選択テキスト翻訳 | ⌘⌃T 自動 / ⌘⌃J →日本語 / ⌘⌃E →英語 |
| `config/keybindings.lua` | HSKeybindings | 自分の HS 登録ショートカット一覧 | ⌘⇧K 表示 |

- ClipboardTool: `paste_on_select=true` / `hist_size=200`。**Maccy 乗り換え候補として当面併用**。テキスト専用（画像は対象外）。Maccy の既定 ⌘⇧C と衝突しないよう履歴表示は ⌘⇧V。
- HSKeybindings は `bindHotkeys` を持たないため `fn` 内で `show()` を手動 bind。
- `init.lua` の require は**確度順（clipboard → translate → keybindings）で末尾追加**。万一未検証の keybindings がエラーでも中核と clipboard/translate は先に読み込まれる。

## 検証について
- ライブ検証はマージ後の `make install ROLE=hammerspoon` → Hammerspoon リロードで（andUse が 3 spoon を取得）。**特に HSKeybindings（⌘⇧K）は API 未検証**なので要確認、ダメなら調整/除外可。
- 取得された spoon（ClipboardTool 等）は `Spoons/.gitignore` により追跡されない（SpoonInstall のみ vendor）。

## 別件メモ
- InputSourceSwitch は「アプリ切替で入力ソース自動切替」＝既存 eikana（左右⌘タップで英数/かな）とは別機能。今回は入れない。
- 画像クリップボードは ClipboardTool 対象外。macOS Spotlight のクリップボード履歴（現 OFF）が画像対応かは未検証で、必要なら別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)