### PR TITLE
feat(macos): Spotlight 検索結果に計算機と辞書を追加

### DIFF
--- a/roles/macos/settings.d/spotlight.sh
+++ b/roles/macos/settings.d/spotlight.sh
@@ -4,7 +4,7 @@ set -e
 # Siri & Spotlight
 # 単体実行: zsh roles/macos/settings.d/spotlight.sh
 # - [x] 「Apple の検索機能の改善に協力」: OFF
-# - [x] 検索結果: Applications / Folders のみ ON（他カテゴリ＋アプリからの結果は OFF）
+# - [x] 検索結果: Applications / Folders / 計算機 / 辞書 を ON（他カテゴリ＋アプリからの結果は OFF）
 # - [x] Spotlight 内のクリップボード履歴: OFF（クリップボード管理は Maccy を使うため）
 #
 # ※ macOS 26 Tahoe の実測キャプチャ由来（EnabledPreferenceRules は非公開スキーマ）。
@@ -15,8 +15,9 @@ set -e
 ## 「Apple の検索機能の改善に協力」OFF（2 = opt-out）
 defaults write com.apple.assistant.support "Search Queries Data Sharing Status" -int 2
 
-## 検索結果: Applications / Folders のみ ON
+## 検索結果: Applications / Folders / 計算機 / 辞書 を ON
 ## （下記に列挙した源が OFF になる。全 ON = 空配列。-array で置換＝冪等）
+## ※ 計算機(com.apple.calculator)・辞書(com.apple.Dictionary) は配列から外して ON に戻した
 defaults write com.apple.Spotlight EnabledPreferenceRules -array \
   "Custom.relatedContents" \
   "System.iphoneApps" \
@@ -35,8 +36,6 @@ defaults write com.apple.Spotlight EnabledPreferenceRules -array \
   "com.apple.MobileSMS" \
   "com.apple.Notes" \
   "com.apple.reminders" \
-  "com.apple.calculator" \
-  "com.apple.Dictionary" \
   "com.apple.Photos" \
   "com.apple.AddressBook"
 


### PR DESCRIPTION
## 概要
Spotlight の検索結果に **計算機（Calculator）** と **辞書（Dictionary）** を表示（ON）する。`spotlight.sh` の `EnabledPreferenceRules`（＝OFF にした源の配列）から `com.apple.calculator` と `com.apple.Dictionary` を外すだけ。

## 補足
- 配列は元の実測キャプチャ（全 ON をベースラインに理想形との差分で確定した「OFF リスト」）なので、2 要素を外すのは **ON への確実な逆操作**（再キャプチャ不要・`-array` 置換で冪等）。
- 配列は 21→19 要素。`zsh -n` 構文チェック OK。

## マージ後の確認
`make install ROLE=macos`（または `zsh roles/macos/settings.d/spotlight.sh`）→ ⌘Space で
- `2+2` 等 → 計算機の結果が出る
- 適当な英単語 → 辞書の定義が出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)